### PR TITLE
Sidebar navigation + demo-first component pages

### DIFF
--- a/app/_components/site-shell.tsx
+++ b/app/_components/site-shell.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { NavGroup } from "@/lib/nav-data";
+
+/**
+ * The persistent left sidebar, and the one rule that keeps it from breaking
+ * the quality gate:
+ *
+ * `/preview/<name>` (the BARE route, no `/play`) is what `scripts/verify.ts`
+ * and `scripts/record.ts` screenshot, and what every catalog card and the
+ * playground embed in an iframe. It must stay a naked component page — the
+ * gate grabs "the first visible interactive element" for its hover/press/focus
+ * diff, and a sidebar full of links would hand it a nav link instead. So that
+ * one shape renders children with no chrome at all.
+ */
+const isBarePreview = (pathname: string) =>
+  /^\/preview\/[^/]+$/.test(pathname);
+
+const LINK =
+  "block truncate rounded-sm px-2 py-1 text-sm outline-none transition-colors hover:bg-surface hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none";
+
+export function SiteShell({
+  groups,
+  children,
+}: {
+  groups: NavGroup[];
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const activeRef = useRef<HTMLAnchorElement | null>(null);
+
+  // Close the mobile drawer on navigation — otherwise tapping a component
+  // leaves the panel covering the thing you just asked to see.
+  useEffect(() => setOpen(false), [pathname]);
+
+  // The list is long enough that the active item is routinely scrolled out
+  // of view (arriving via a catalog card, a direct link, prev/next) — so pull
+  // it into the middle of the panel rather than leaving the visitor to hunt.
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "center" });
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const active = pathname.startsWith("/preview/")
+    ? pathname.split("/")[2]
+    : null;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return groups;
+    return groups
+      .map((g) => ({
+        ...g,
+        items: g.items.filter(
+          (i) =>
+            i.name.includes(q) || i.title.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [groups, query]);
+
+  const total = useMemo(
+    () => groups.reduce((n, g) => n + g.items.length, 0),
+    [groups],
+  );
+  const shown = useMemo(
+    () => filtered.reduce((n, g) => n + g.items.length, 0),
+    [filtered],
+  );
+
+  if (isBarePreview(pathname)) return <>{children}</>;
+
+  return (
+    <div className="lg:flex">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="site-nav"
+        className="fixed left-3 top-3 z-50 inline-flex h-11 w-11 items-center justify-center rounded-md border border-border bg-background text-muted outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent lg:hidden"
+      >
+        <span className="sr-only">
+          {open ? "Close component navigation" : "Open component navigation"}
+        </span>
+        <MenuIcon open={open} />
+      </button>
+
+      {open ? (
+        <div
+          onClick={() => setOpen(false)}
+          className="fixed inset-0 z-30 bg-background/70 lg:hidden"
+        />
+      ) : null}
+
+      <nav
+        id="site-nav"
+        aria-label="Components"
+        className={`fixed inset-y-0 left-0 z-40 flex w-[17rem] flex-col border-r border-border bg-background transition-transform lg:sticky lg:top-0 lg:h-screen lg:translate-x-0 motion-reduce:transition-none ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        {/* pl-14 clears the fixed mobile toggle button (44px, left-3 top-3),
+            which otherwise sits directly on top of the wordmark once the
+            drawer is open. Not needed at lg — the toggle is hidden there. */}
+        <div className="flex items-center justify-between gap-2 pb-3 pl-14 pr-4 pt-4 lg:pl-4 lg:pt-5">
+          <Link
+            href="/"
+            className="rounded-sm font-mono text-sm tracking-tight outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            ns-ui
+          </Link>
+          <span className="font-mono text-[11px] text-muted">{total}</span>
+        </div>
+
+        <div className="px-4 pb-3">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter components"
+            aria-label="Filter components"
+            className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-sm outline-none placeholder:text-muted focus-visible:ring-2 focus-visible:ring-accent"
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-6">
+          {query && shown === 0 ? (
+            <p className="px-2 py-3 text-sm text-muted">No match.</p>
+          ) : null}
+          {filtered.map((g) => (
+            <section key={g.id} className="mb-4">
+              <h2 className="px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted">
+                {g.label}
+              </h2>
+              <ul>
+                {g.items.map((i) => {
+                  const on = i.name === active;
+                  return (
+                    <li key={i.name}>
+                      <Link
+                        ref={on ? activeRef : undefined}
+                        href={`/preview/${i.name}/play`}
+                        aria-current={on ? "page" : undefined}
+                        className={`${LINK} ${
+                          on
+                            ? "bg-surface font-medium text-accent"
+                            : "text-muted"
+                        }`}
+                      >
+                        {i.title}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-3 border-t border-border px-4 py-3 font-mono text-[11px] text-muted">
+          <Link
+            href="/changelog"
+            className="rounded-sm outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Changelog
+          </Link>
+          <Link
+            href="/writing"
+            className="rounded-sm outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Writing
+          </Link>
+        </div>
+      </nav>
+
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+function MenuIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="size-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      aria-hidden
+    >
+      {open ? (
+        <path d="M4 4l8 8M12 4l-8 8" />
+      ) : (
+        <path d="M2.5 4.5h11M2.5 8h11M2.5 11.5h11" />
+      )}
+    </svg>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,9 @@ import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import { ThemeSync } from "./_components/theme-sync";
+import { SiteShell } from "./_components/site-shell";
 import { NO_FLASH_SCRIPT } from "@/lib/theme";
+import { navGroups } from "@/lib/nav-data";
 import { REGISTRY_ORIGIN } from "@/lib/registry-origin";
 
 const title = "ns-ui";
@@ -53,7 +55,9 @@ export default function RootLayout({
       </head>
       <body className="bg-background font-sans text-foreground antialiased">
         <ThemeSync />
-        {children}
+        {/* Nav data is computed on the server once per build; the shell is a
+            client component only because it needs the active pathname. */}
+        <SiteShell groups={navGroups()}>{children}</SiteShell>
         {/* Vercel Web Analytics and Speed Insights. Both no-op outside a
             Vercel deployment, so local dev is unaffected. */}
         <Analytics />

--- a/app/preview/[name]/play/page.tsx
+++ b/app/preview/[name]/play/page.tsx
@@ -22,6 +22,11 @@ import { ThemeToggle } from "@/app/_components/theme-toggle";
  * the honest reference page in an iframe instead — `?embed=1&interactive=1`
  * already exists for exactly this (the featured-card thumbnail uses the same
  * URL once activated) and is provably unchanged by this file.
+ *
+ * Layout rule: the component is the page. Everything the visitor might read
+ * *after* deciding they like it — the full description, when to reach for it,
+ * the build spec — sits in closed disclosures under the demo, so the demo is
+ * the first thing in view rather than the fourth.
  */
 export async function generateMetadata({
   params,
@@ -34,6 +39,12 @@ export async function generateMetadata({
   const title = `${item.title} — playground — ns-ui`;
   return { title, description: item.description };
 }
+
+/** The lead sentence carries the component's job; the rest is build detail. */
+const firstSentence = (text: string) => text.split(/(?<=\.)\s/, 1)[0] ?? text;
+
+const SUMMARY =
+  "cursor-pointer select-none rounded-sm font-mono text-xs uppercase tracking-[0.14em] text-muted outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none";
 
 export default async function PlaygroundPage({
   params,
@@ -51,6 +62,8 @@ export default async function PlaygroundPage({
   const collection =
     (item.meta as { collection?: string } | undefined)?.collection ?? "core";
   const installCommand = `npx shadcn add ${REGISTRY_ORIGIN}/r/${name}.json`;
+  const summary = firstSentence(item.description);
+  const hasMore = summary !== item.description;
 
   // Prev/next by recency, not by the homepage's featured-first order — that
   // order changes with curation, this stays stable and covers every
@@ -62,16 +75,10 @@ export default async function PlaygroundPage({
   const older = idx >= 0 && idx < slugs.length - 1 ? slugs[idx + 1] : null;
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-[1600px] flex-col px-6 pb-16 pt-8 sm:px-10">
-      <header className="flex flex-wrap items-start justify-between gap-4">
+    <div className="mx-auto flex min-h-screen w-full max-w-[1400px] flex-col px-6 pb-16 pt-6 sm:px-10 lg:pt-8">
+      <header className="flex items-start justify-between gap-4 pl-14 lg:pl-0">
         <div className="min-w-0">
-          <Link
-            href="/"
-            className="inline-flex items-center gap-1.5 rounded-sm font-mono text-xs uppercase tracking-[0.14em] text-muted outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none"
-          >
-            <BackIcon /> All components
-          </Link>
-          <div className="mt-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
             <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
               {item.title}
             </h1>
@@ -81,104 +88,131 @@ export default async function PlaygroundPage({
               </span>
             ) : null}
           </div>
-          <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted">
-            {item.description}
+          <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-muted">
+            {summary}
           </p>
         </div>
-        <ThemeToggle />
-      </header>
-
-      {useWhen ? (
-        <p className="mt-5 max-w-2xl rounded-md border border-border bg-surface px-4 py-3 text-xs leading-relaxed text-muted">
-          <span className="font-mono uppercase tracking-wider text-foreground">
-            Use when
-          </span>{" "}
-          {useWhen}
-        </p>
-      ) : null}
-
-      <div className="mt-5 flex flex-wrap items-start gap-3">
-        <div className="flex min-w-0 max-w-xl flex-1 items-start gap-2 rounded-md border border-border bg-surface py-2 pl-3.5 pr-1.5">
-          <code className="min-w-0 flex-1 break-words font-mono text-xs leading-6 text-foreground">
-            npx shadcn add {REGISTRY_ORIGIN}
-            <wbr />
-            /r/{name}.json
-          </code>
+        <div className="flex shrink-0 items-center gap-1">
           <CopyButton
             variant="inline"
             value={installCommand}
             label="Copy install command"
           />
+          <NavArrow href={older} label="Older component" />
+          <NavArrow href={newer} label="Newer component" flip />
+          <ThemeToggle />
         </div>
-        {tags.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-1.5 pt-1.5">
-            {tags.map((t) => (
-              <span
-                key={t}
-                className="rounded-full border border-border px-2 py-0.5 font-mono text-[11px] text-muted"
-              >
-                {t}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </div>
+      </header>
 
       {/* Fully interactive, uninert, not autoplaying — `interactive=1` on the
           honest reference page. Full real viewport (no scale transform), so
           this is exactly what the direct link renders, breathing room and
           all — the thing the owner asked to "play with". */}
-      <div className="mt-8 flex-1 overflow-hidden rounded-md border border-border bg-surface">
+      <div className="mt-5 flex-1 overflow-hidden rounded-md border border-border bg-surface">
         <iframe
           key={name}
           src={`/preview/${name}?embed=1&interactive=1`}
           title={`${item.title} — interactive`}
-          className="h-[75vh] min-h-[520px] w-full border-0 bg-transparent"
+          className="h-[76vh] min-h-[520px] w-full border-0 bg-transparent"
         />
       </div>
 
-      {instruction ? (
-        <details className="mt-8 rounded-md border border-border bg-surface px-4 py-3">
-          <summary className="cursor-pointer select-none font-mono text-xs uppercase tracking-[0.14em] text-muted outline-none focus-visible:ring-2 focus-visible:ring-accent">
-            Build spec
-          </summary>
-          <p className="mt-3 whitespace-pre-wrap font-mono text-xs leading-relaxed text-muted">
-            {instruction}
-          </p>
+      <div className="mt-6 divide-y divide-border border-y border-border">
+        <details className="group py-3">
+          <summary className={SUMMARY}>Install</summary>
+          <div className="mt-3 flex max-w-xl items-start gap-2 rounded-md border border-border bg-surface py-2 pl-3.5 pr-1.5">
+            <code className="min-w-0 flex-1 break-words font-mono text-xs leading-6 text-foreground">
+              npx shadcn add {REGISTRY_ORIGIN}
+              <wbr />
+              /r/{name}.json
+            </code>
+            <CopyButton
+              variant="inline"
+              value={installCommand}
+              label="Copy install command"
+            />
+          </div>
         </details>
-      ) : null}
 
-      <nav className="mt-10 flex items-center justify-between gap-4 border-t border-border pt-5 font-mono text-xs text-muted">
-        {older ? (
-          <Link
-            href={`/preview/${older}/play`}
-            className="inline-flex items-center gap-1.5 rounded-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none"
-          >
-            <BackIcon /> Older
-          </Link>
-        ) : (
-          <span />
-        )}
-        {newer ? (
-          <Link
-            href={`/preview/${newer}/play`}
-            className="inline-flex items-center gap-1.5 rounded-sm outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none"
-          >
-            Newer <BackIcon className="rotate-180" />
-          </Link>
-        ) : (
-          <span />
-        )}
-      </nav>
+        {useWhen || hasMore ? (
+          <details className="py-3">
+            <summary className={SUMMARY}>Use when</summary>
+            {hasMore ? (
+              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted">
+                {item.description}
+              </p>
+            ) : null}
+            {useWhen ? (
+              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted">
+                {useWhen}
+              </p>
+            ) : null}
+          </details>
+        ) : null}
+
+        {instruction ? (
+          <details className="py-3">
+            <summary className={SUMMARY}>Build spec</summary>
+            <p className="mt-3 max-w-3xl whitespace-pre-wrap font-mono text-xs leading-relaxed text-muted">
+              {instruction}
+            </p>
+          </details>
+        ) : null}
+
+        {tags.length > 0 ? (
+          <details className="py-3">
+            <summary className={SUMMARY}>Tags</summary>
+            <div className="mt-3 flex flex-wrap items-center gap-1.5">
+              {tags.map((t) => (
+                <span
+                  key={t}
+                  className="rounded-full border border-border px-2 py-0.5 font-mono text-[11px] text-muted"
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+          </details>
+        ) : null}
+      </div>
     </div>
   );
 }
 
-function BackIcon({ className = "" }: { className?: string }) {
+function NavArrow({
+  href,
+  label,
+  flip = false,
+}: {
+  href: string | null;
+  label: string;
+  flip?: boolean;
+}) {
+  const shared =
+    "inline-flex size-8 items-center justify-center rounded-sm text-muted";
+  if (!href) {
+    return (
+      <span className={`${shared} opacity-30`} aria-hidden>
+        <Chevron flip={flip} />
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={`/preview/${href}/play`}
+      aria-label={label}
+      className={`${shared} outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none`}
+    >
+      <Chevron flip={flip} />
+    </Link>
+  );
+}
+
+function Chevron({ flip }: { flip: boolean }) {
   return (
     <svg
       viewBox="0 0 16 16"
-      className={`size-3.5 ${className}`}
+      className={`size-3.5 ${flip ? "rotate-180" : ""}`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1.25"

--- a/lib/nav-data.ts
+++ b/lib/nav-data.ts
@@ -1,0 +1,53 @@
+import registry from "@/registry.json";
+import order from "@/lib/component-order.json";
+import { CATEGORIES, categorize } from "@/lib/search-categories";
+
+export type NavItem = { name: string; title: string; loud: boolean };
+export type NavGroup = { id: string; label: string; items: NavItem[] };
+
+/**
+ * The sidebar's grouped component list.
+ *
+ * `categorize()` returns EVERY category a component belongs to, which is right
+ * for filter chips (a chip should find it) and wrong for a nav tree (the same
+ * slug appearing under four headings reads as four components). So each
+ * component is placed in its FIRST matching category only — CATEGORIES order
+ * is already curated newcomer-first — and anything with no match lands in
+ * "Other" rather than disappearing.
+ */
+export function navGroups(): NavGroup[] {
+  const items = registry.items.map((i) => ({
+    name: i.name,
+    title: i.title,
+    tags: i.meta?.tags ?? [],
+    loud: (i.meta?.collection ?? "core") === "loud",
+  }));
+
+  const memberships = categorize(items);
+  const rank = new Map((order as string[]).map((name, i) => [name, i]));
+  const buckets = new Map<string, NavItem[]>();
+
+  for (const item of items) {
+    const id = memberships.get(item.name)?.[0] ?? "other";
+    const list = buckets.get(id) ?? [];
+    list.push({ name: item.name, title: item.title, loud: item.loud });
+    buckets.set(id, list);
+  }
+
+  // Newest first inside a group, same recency snapshot the catalog sorts by.
+  const byRecency = (a: NavItem, b: NavItem) =>
+    (rank.get(a.name) ?? Number.MAX_SAFE_INTEGER) -
+    (rank.get(b.name) ?? Number.MAX_SAFE_INTEGER);
+
+  const groups: NavGroup[] = CATEGORIES.map((c) => ({
+    id: c.id,
+    label: c.label,
+    items: (buckets.get(c.id) ?? []).sort(byRecency),
+  })).filter((g) => g.items.length > 0);
+
+  const other = buckets.get("other");
+  if (other?.length) {
+    groups.push({ id: "other", label: "Other", items: other.sort(byRecency) });
+  }
+  return groups;
+}


### PR DESCRIPTION
## What

Two changes to how components are browsed and read.

**Persistent left sidebar, site-wide.** All 206 components grouped into the existing `search-categories.ts` buckets, with a filter input, active-item highlight, and a mobile off-canvas drawer. A dock-style bar was considered and rejected — 206 items need search, grouping and a "you are here" marker, none of which a dock has.

**Component pages lead with the component.** The playground previously stacked a back link, title, full description, a "Use when" box, the install command and a tag row above the demo — four blocks before you saw the thing. Now: title + one-sentence summary + demo, with description, install, use-when, build spec and tags in closed disclosures underneath. Prev/next moved into the header as chevrons.

## The invariant this had to respect

`/preview/<name>` (bare, no `/play`) is what `scripts/verify.ts` and `scripts/record.ts` screenshot, and what every catalog card and the playground iframe. `SiteShell` renders children with zero chrome on that exact path shape, so the gate still grabs the component's own first interactive element rather than a nav link. Verified: `curl /preview/dovetail-run | grep -c site-nav` → 0.

## Verified

Playwright screenshots at 1440x900 (dark + light, confirmed not byte-identical), 420x860 (drawer closed and open), plus `/`, `/changelog`, `/writing` and the bare preview route. Two real defects found in the pixels and fixed: the active sidebar item was scrolled out of view on load, and the mobile close button covered the sidebar wordmark. `npm run build` and `npx tsc --noEmit` pass.