### PR TITLE
fix: ramp-trace readout drifted from its column, and a wiki note

### DIFF
--- a/registry/core/ramp-trace/component.tsx
+++ b/registry/core/ramp-trace/component.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 // 8 sub-row block-fraction glyphs, 1/8 full to 8/8 full
 const BLOCKS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
 const ROWS = 8;
 const COL_W = 1; // ch, one glyph per column
 const COL_GAP = 0.6; // ch, whitespace between columns
-const PITCH = COL_W + COL_GAP;
 
 export interface RampTraceProps {
   /** the series to plot; needs at least one value */
@@ -35,6 +34,32 @@ export function RampTrace({
   const [focusIdx, setFocusIdx] = useState<number | null>(null);
   const activeIdx = hoverIdx ?? focusIdx;
   const colRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // the readout is centered on the active column's own measured position,
+  // not a parallel `ch`-based pitch calculation: the readout row and the
+  // bar row can differ in font-size (e.g. text-xs vs the ambient size),
+  // which makes `ch` resolve to different px in each row and drift
+  // linearly with column index. Measuring the real element sidesteps
+  // that entirely.
+  const [readoutCenter, setReadoutCenter] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (activeIdx === null) {
+      setReadoutCenter(null);
+      return;
+    }
+    const update = () => {
+      const col = colRefs.current[activeIdx];
+      const container = containerRef.current;
+      if (!col || !container) return;
+      const colRect = col.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      setReadoutCenter(colRect.left - containerRect.left + colRect.width / 2);
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [activeIdx]);
 
   const moveFocus = (i: number) => {
     const clamped = Math.min(series.length - 1, Math.max(0, i));
@@ -87,13 +112,13 @@ export function RampTrace({
   };
 
   return (
-    <div className={`font-mono ${className}`}>
+    <div ref={containerRef} className={`font-mono ${className}`}>
       <div className="relative h-[1.1em] text-xs" style={{ lineHeight: "1.1em" }}>
-        {activeIdx !== null ? (
+        {activeIdx !== null && readoutCenter !== null ? (
           <span
             aria-hidden
-            className="absolute bottom-0 whitespace-nowrap text-accent"
-            style={{ left: `${activeIdx * PITCH}ch` }}
+            className="absolute bottom-0 -translate-x-1/2 whitespace-nowrap text-accent"
+            style={{ left: `${readoutCenter}px` }}
           >
             {valueFormat(series[activeIdx])}
           </span>

--- a/wiki/_index.md
+++ b/wiki/_index.md
@@ -11,6 +11,8 @@ updated: 2026-07-28T16:20:53Z
 
 [[inline_style_overrides_tailwind_position|inline_style_overrides_tailwind_position]]: A component-scoped <style> rule at equal specificity beats Tailwind utilities by source order — never re-declare position (or other box-critical props) on an element that already carries a Tailwind position utility; an absolute inset-0 wrapper silently flipped to relative collapses to height 0 when all its children are absolute.
 
+[[mono_glyph_family_baseline_mismatch|mono_glyph_family_baseline_mismatch]]: Box-drawing glyphs render centred in the em box while block-fraction glyphs sit flush to the baseline — the two families cannot be aligned in one monospace character grid by row arithmetic, no matter how correct the row index is.
+
 [[raf_negative_delta_first_frame|raf_negative_delta_first_frame]]: A rAF callback's timestamp can read marginally behind a performance.now() sample taken just before requestAnimationFrame was scheduled — clamp raw = now - lastSample to >= 0 or a fresh animation's first frame computes a tiny negative delta and poisons anything downstream (eased progress going negative, negative radii, etc).
 
 [[svg_dasharray_non_scaling_stroke|svg_dasharray_non_scaling_stroke]]: Chromium ignores pathLength for stroke-dasharray when vectorEffect="non-scaling-stroke" is set — never combine them; use divs for straight indicator lines.

--- a/wiki/mono_glyph_family_baseline_mismatch.md
+++ b/wiki/mono_glyph_family_baseline_mismatch.md
@@ -1,0 +1,66 @@
+---
+name: mono_glyph_family_baseline_mismatch
+desc: Box-drawing glyphs render centred in the em box while block-fraction glyphs sit flush to the baseline — the two families cannot be aligned in one monospace character grid by row arithmetic, no matter how correct the row index is.
+created: 2026-07-30T08:40:00Z
+updated: 2026-07-30T08:40:00Z
+---
+
+# mono_glyph_family_baseline_mismatch
+
+A character-grid component that mixes **block-fraction glyphs**
+(`▁▂▃▄▅▆▇█`, U+2581-2588) with **box-drawing glyphs** (`╱ ╲ ─ │ ┌ ┐`,
+U+2500 block) will render the two families at different vertical positions
+*within the same grid row*. This is a font-metric property, not a layout
+bug, and it cannot be corrected by fixing the row index.
+
+- Block-fraction glyphs are designed to tile a filled cell. They sit flush
+  to the cell's baseline and grow upward, which is what makes them usable
+  as bar-chart fills.
+- Box-drawing glyphs are designed to connect to their neighbours. They are
+  centred in the em box so a `─` meets the `─` beside it at mid-height.
+
+Put a `╱` and a `█` in the same row and the `╱` floats above the `█`.
+
+## How this presented
+
+`ramp-trace` drew bars from block-fraction glyphs and a trend line from
+`╱ ╲ ─`. The trend line rendered visibly detached, floating above the bar
+tops, reading as a rendering fault rather than a chart.
+
+The first cause found was real but insufficient: the line's row index was
+computed as `round(norm * (ROWS - 1))` while the bar heights used
+`floor(norm * ROWS * 8) / 8`, so different rounding put the line a row off.
+Fixing that to derive both from the same fullRows/remainder arithmetic was
+verified correct by substituting `█` for the trend glyph, which then sat
+flush on the bar top with no gap.
+
+With the real `╱ ╲ ─` glyphs restored, the float came straight back. Same
+row, same arithmetic, different family, different vertical position.
+
+## What to do
+
+**Do not** try to correct it with a per-glyph CSS nudge (`translateY`, a
+tweaked `line-height`, a negative margin). The offset depends on the font's
+metrics, so a value tuned against GeistMono breaks under any fallback font,
+and the fallback is what renders before `document.fonts.ready`.
+
+Pick one:
+
+1. **Use one family for anything that must align.** Draw the line out of
+   block glyphs too, or draw the bars out of box-drawing glyphs. Alignment
+   is then free.
+2. **Drop the overlay.** This is what `ramp-trace` did. A clean bar chart
+   reads better than a bar chart with a detached line through it, and the
+   removal also took an orphan glyph on the last column with it.
+3. **Render to canvas instead of a DOM text grid** if both families are
+   genuinely required, since `fillText` lets you place each glyph at an
+   explicit y and measure it with `measureText` rather than inheriting
+   line-box behaviour.
+
+## Related
+
+The same "measure, do not assume" principle applies to cell width: measure
+the mono advance with `measureText` on an offscreen canvas gated on
+`document.fonts.ready`, never at mount, or a fallback-font measurement
+bakes in the wrong ratio until reload. See the loud ASCII components
+(`torus-render`, `meridian-spin`, `glyph-tide`) for that pattern.


### PR DESCRIPTION
## The defect
`ramp-trace`'s value readout positioned itself with a parallel pitch calculation, `activeIdx * (COL_W + COL_GAP)ch`, while the bars advanced by their own layout. That row is `text-xs`; the bar row inherits the ambient font size. **`ch` is font-relative**, so the same numeric pitch resolved to a different pixel width in each row and the error accumulated with column index.

Measured before the fix, at 1280x620:

| column | column centre | readout centre | drift |
|---|---|---|---|
| 3 | 355 | 353 | 2px |
| 12 | 493 | 457 | 36px |
| 25 | 692 | 606 | 86px |

At the right-hand end the readout labelled a bar roughly three columns away from the one it described. A constant offset would have been a centering mistake; linear accumulation pointed at two systems disagreeing on pitch.

## The fix
Deleted the parallel pitch entirely. The readout now centres on the selected column's own measured position, recomputed on selection change and resize, so there is no second pitch to keep in sync.

Verified at 0px deviation across columns 3, 12 and 25, at both 1280 and 900 width, under hover and arrow-key selection, independently re-measured after the fix.

Untouched: `aria-selected` still follows DOM focus alone while the inversion follows hover-or-focus, the solid-column selection fill, and the absence of the trend overlay.

## Wiki note
Adds `wiki/mono_glyph_family_baseline_mismatch.md`. Box-drawing glyphs render centred in the em box while block-fraction glyphs sit flush to the baseline, so the two families cannot be aligned in one character grid by row arithmetic however correct the row index is. That is what defeated `ramp-trace`'s trend overlay earlier today, after the row arithmetic had already been fixed and proven correct by substituting a block glyph.

A CSS nudge is the wrong fix: the offset is font-metric dependent, and the fallback font is what renders before `document.fonts.ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)