### PR TITLE
fix: recurate FEATURED, and stop the chip row clipping its last label

### DIFF
--- a/app/_components/catalog-controls.tsx
+++ b/app/_components/catalog-controls.tsx
@@ -20,9 +20,12 @@ const TABS: { key: Filter; label: string }[] = [
 /**
  * The sticky filter/sort/search cluster, pulled out of Showcase so that
  * component stays the state owner and this one stays a pure props-in,
- * callbacks-out view. Two rows at every width: tabs + search + sort share
- * row one, category chips + result state share row two — down from three,
- * which was crowding the 375px viewport.
+ * callbacks-out view. Tabs + search + sort share row one; category chips
+ * + result state share row two, with the chips wrapping onto extra lines
+ * (instead of scrolling off-screen) once they don't fit one line — the
+ * chip count outgrew a single row a while back and a horizontal-scroll
+ * region just clipped the last chip mid-label with no affordance to
+ * reveal the rest.
  *
  * Sort deliberately does NOT use the accent-filled pill treatment the
  * category chips use — accent is reserved for chips because those are a
@@ -164,11 +167,11 @@ export function CatalogControls({
         </div>
       </div>
 
-      <div className="mt-2.5 flex items-center gap-2">
+      <div className="mt-2.5 flex items-start gap-2">
         <div
           role="group"
           aria-label="Filter by what the component is for"
-          className="-mb-1 flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto pb-1"
+          className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-2"
         >
           {categories.map((c) => {
             const on = category === c.id;
@@ -195,7 +198,7 @@ export function CatalogControls({
 
         {/* Single live region for the result count — was previously
             duplicated with a second "n shown" readout in row one. */}
-        <p aria-live="polite" className="shrink-0 whitespace-nowrap font-mono text-[11px] text-muted sm:text-xs">
+        <p aria-live="polite" className="shrink-0 whitespace-nowrap py-1 font-mono text-[11px] text-muted sm:text-xs">
           {filtered ? `${visibleCount} of ${totalCount}` : `${totalCount} shown`}
           {activeCategory ? ` · ${activeCategory.label}` : ""}
         </p>

--- a/lib/featured.ts
+++ b/lib/featured.ts
@@ -13,19 +13,40 @@
  * dropped by the filter in `app/page.tsx` rather than crashing the build.
  */
 export const FEATURED: string[] = [
-  "gnomon-set",
-  "tumbler-gate",
-  "cipher-reel-otp",
-  "dovetail-run",
-  "sieve-facets",
-  "ridge-walk",
+  // Front of the rail: the most immediately striking work, alternating
+  // collections so the first screen shows both registers rather than reading
+  // as one. The list was 18 core to 2 loud, which sold the showcase short and
+  // made the grid look more uniform than the registry actually is.
+  "glyph-tide", // loud   full-bleed ASCII plasma, drag through it
+  "caustic-coverflow", // core   drag to scrub, flick for momentum
+  "torus-render", // loud   ASCII torus, real depth buffer, drag-rotate
+  "particle-hero", // core   a field that answers the cursor
+  "vanish-run", // loud   perspective corridor, cursor steers the vanishing point
+  "glyph-cast", // core   block-letter wordmark lit by the pointer
+  "meridian-spin", // loud   ASCII globe with a day/night terminator
+  "crack-compare", // core   the before/after divider is a fracture
+  "oscillo-crest", // loud   oscilloscope trace, pointer rings the wave
+  "wake-glyph", // core   cursor wake with velocity-dependent decay
+  "scarp-horizon", // loud   layered ridgelines, per-layer parallax
+  "ridge-walk", // core   pick a point on a pareto frontier
+  "nested-slug", // loud   wordmark whose letterforms are made of readable text
+  "bough-index", // core   tree whose connectors redraw as it collapses
+  "chladni-tune", // loud   sand locks into a symmetric figure on target
+  "gnomon-set", // core   sundial time picker
+  "knockout-404", // loud   type carved out of the surface
+  "tumbler-gate", // core   align the notch, hold, confirm
+  "frost-scrub", // loud   scroll is the defroster
+  "cipher-reel-otp", // core   OTP reels
+  "burin-etch", // loud   contour hatch, pointer polishes a trail
+  "dovetail-run", // core
+  "singularity-text", // loud
+  "sieve-facets", // core
+  // Tail: the rest of the previous curation, order preserved.
   "scissor-reach",
   "flywheel-pull",
   "hump-yard",
   "after-image",
-  "chladni-tune",
   "lodestone-hero",
-  "caustic-coverflow",
   "warp-lattice",
   "vortex-street",
   "mercury-minimap",


### PR DESCRIPTION
Two site-chrome changes. No `registry/` components touched.

## 1. FEATURED recurated

The array was **18 core to 2 loud**. Since the homepage sorts featured-first, that array decides the entire first screen, so the grid read as far more uniform than the registry actually is and the showcase collection was invisible above the fold.

Now 36 slugs, 23 core to 13 loud, with the first sixteen alternating collection. Front of the rail is the most immediately legible work rather than the most recent:

`glyph-tide` · `caustic-coverflow` · `torus-render` · `particle-hero` · `vanish-run` · `glyph-cast` · `meridian-spin` · `crack-compare`

Nine of today's sixteen new components are included. **Every previously featured slug is retained and the tail order is preserved**, so this only adds and reorders. Validated for missing slugs and duplicates, since the file's own comment notes a stale slug is silently dropped by the filter in `app/page.tsx` rather than failing the build.

## 2. Chip row clipping

Not the overlap it first looked like, and the original diagnosis was wrong. The reported 6px collision with the "N shown" label was a measurement artefact: `getBoundingClientRect()` on a chip inside an `overflow-x-auto` container returns the full **unclipped** box, including the portion scrolled out of view. The container's real clipped edge sat 8px clear of the label.

The actual defect: the row was a single-line `overflow-x-auto` scroller, so at `scrollLeft=0` it cut the last label mid-word ("Media 1" where "Media 11" belongs) with no affordance whatsoever. No fade, no arrow, and macOS overlay scrollbars are invisible at rest, so it read as a broken layout rather than as something scrollable. `scrollWidth > clientWidth` at every width tested, meaning the row was always truncating something.

Fixed by wrapping rather than scrolling, which is the pattern the first row in this same file already uses. `items-start` on the outer row since the chip block can now run two or three lines, and `py-1` on the count so its baseline aligns with the first chip line.

Verified at 1440, 1280, 1024 and 768: `scrollWidth === clientWidth` (nothing clipped, no scroll region remaining), pairwise rect intersection against the count label empty at every width, and confirmed by screenshot rather than by numbers alone.

## Known, not addressed here
`preview-card.tsx` uses a static `scroll-mt-24` (96px) for anchor-scroll offset while the sticky filter bar is taller than that. This was already an under-offset before this change; wrapping makes it roughly 34px worse at 1024 and below. Pre-existing, separate component, left alone deliberately rather than folded into a chrome fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)