### PR TITLE
feat: live star count on the CTA, and two layout fixes

### DIFF
--- a/app/_components/catalog-controls.tsx
+++ b/app/_components/catalog-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 export type Filter = "all" | "core" | "loud";
 export type Sort = "featured" | "newest" | "oldest";
@@ -65,6 +65,23 @@ export function CatalogControls({
   onClearAll: () => void;
 }) {
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const barRef = useRef<HTMLDivElement | null>(null);
+
+  // Publishes the bar's real height as a CSS variable so a card's
+  // scroll-mt (preview-card.tsx) can clear it exactly instead of guessing a
+  // static number — the chip row wraps onto extra lines at narrower widths
+  // and the Clear button appears/disappears with `filtered`, both of which
+  // change this height at runtime.
+  useLayoutEffect(() => {
+    const el = barRef.current;
+    if (!el) return;
+    const set = () =>
+      document.documentElement.style.setProperty("--filter-bar-h", `${el.offsetHeight}px`);
+    set();
+    const ro = new ResizeObserver(set);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   // "/" focuses search — standard, cheap, and ignored while any text input
   // (this one included) or a contenteditable already has focus, so it never
@@ -85,7 +102,10 @@ export function CatalogControls({
   const activeCategory = categories.find((c) => c.id === category);
 
   return (
-    <div className="sticky top-0 z-30 -mx-6 mt-14 border-b border-border bg-background/85 px-6 py-3 backdrop-blur sm:-mx-10 sm:px-10">
+    <div
+      ref={barRef}
+      className="sticky top-0 z-30 -mx-6 mt-14 border-b border-border bg-background/85 px-6 py-3 backdrop-blur sm:-mx-10 sm:px-10"
+    >
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2.5">
         {/* Plain toggle buttons, not an ARIA tablist — there's no associated
             tabpanel and no arrow-key navigation, so `role="tab"` promised a

--- a/app/_components/github-star-button.tsx
+++ b/app/_components/github-star-button.tsx
@@ -2,6 +2,13 @@ import { LiquidCollar } from "@/registry/loud/liquid-collar/component";
 
 const REPO_URL = "https://github.com/nikolas-sapa/ns-ui";
 
+/** `1234` -> `1,234`, `12400` -> `12.4k`. Matches at a glance rather than to
+ *  the digit, which is all a header CTA needs. */
+function formatStarCount(count: number): string {
+  if (count < 1000) return count.toLocaleString("en-US");
+  return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+}
+
 /**
  * The star CTA. Two placements share one component so the copy and target
  * never drift apart, but only the hero gets the LiquidCollar treatment —
@@ -13,24 +20,39 @@ const REPO_URL = "https://github.com/nikolas-sapa/ns-ui";
  * effect (see registry/loud/liquid-collar/component.tsx), so the link is
  * always in the DOM and clickable even where WebGL is unavailable or a
  * shader fails to compile — the ring is a visual bonus, never a dependency.
+ *
+ * `stars` is fetched server-side (see lib/github-stars.ts) and passed down
+ * rather than fetched here — this stays a client component for the hover/
+ * focus states, and a client-side fetch would mean a loading state, a
+ * layout shift once it resolves, and one API call per visitor against
+ * GitHub's 60/hour unauthenticated limit instead of one per hour. `null`
+ * (fetch failed, or not threaded through) renders exactly as before: no
+ * count, no divider, same height either way.
  */
 export function GitHubStarButton({
   variant = "collar",
   className = "",
+  stars = null,
 }: {
   variant?: "collar" | "quiet";
   className?: string;
+  stars?: number | null;
 }) {
+  const label = variant === "quiet" ? "Star ns-ui on GitHub" : "Star on GitHub";
+  const ariaLabel = stars !== null ? `${label}, ${stars.toLocaleString("en-US")} stars` : undefined;
+
   if (variant === "quiet") {
     return (
       <a
         href={REPO_URL}
         target="_blank"
         rel="noopener noreferrer"
+        aria-label={ariaLabel}
         className={`inline-flex items-center gap-2 rounded-sm border border-border px-4 py-2 text-sm text-foreground outline-none transition-colors hover:border-muted hover:bg-surface focus-visible:ring-2 focus-visible:ring-accent ${className}`}
       >
         <StarIcon />
-        Star ns-ui on GitHub
+        {label}
+        <StarCount stars={stars} />
       </a>
     );
   }
@@ -46,13 +68,30 @@ export function GitHubStarButton({
         href={REPO_URL}
         target="_blank"
         rel="noopener noreferrer"
+        aria-label={ariaLabel}
         style={{ borderRadius: 6 }}
         className="inline-flex items-center gap-2 bg-surface px-4 py-2 text-sm font-medium text-foreground outline-none transition-colors hover:bg-border/60 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       >
         <StarIcon />
-        Star on GitHub
+        {label}
+        <StarCount stars={stars} />
       </a>
     </LiquidCollar>
+  );
+}
+
+/** The count, set off from the label by the same border token used
+ *  everywhere else so it reads as a counter rather than trailing words in
+ *  the sentence. `aria-hidden` because the parent link's `aria-label`
+ *  already speaks the count when it's present. Renders nothing — no
+ *  divider, no width — when the count is unavailable, so the button's
+ *  height and shape never depend on the fetch. */
+function StarCount({ stars }: { stars: number | null }) {
+  if (stars === null) return null;
+  return (
+    <span aria-hidden className="ml-0.5 flex items-center gap-2 border-l border-border pl-2 font-mono text-xs tabular-nums text-muted">
+      {formatStarCount(stars)}
+    </span>
   );
 }
 

--- a/app/_components/preview-card.tsx
+++ b/app/_components/preview-card.tsx
@@ -168,10 +168,16 @@ export function PreviewCard({
   return (
     <article
       ref={setCardRef}
+      id={entry.name}
       data-name={entry.name}
       data-mounted={mounted ? "true" : "false"}
       data-loaded={loaded ? "true" : "false"}
-      className="group relative flex scroll-mt-24 flex-col"
+      // Clears the sticky filter bar (catalog-controls.tsx) by its measured
+      // height rather than a magic number — the bar's chip row wraps at
+      // narrower widths and grows taller than any static value would assume.
+      // The 6rem fallback matches today's static offset for the brief window
+      // before the bar has measured itself (or if JS never runs).
+      className="group relative flex scroll-mt-[calc(var(--filter-bar-h,6rem)+0.75rem)] flex-col"
     >
       {/* Aspect-locked from first paint, so the frame arriving shifts nothing. */}
       <div

--- a/app/_components/showcase.tsx
+++ b/app/_components/showcase.tsx
@@ -72,10 +72,13 @@ const QUERY_PARAM = "q";
 export function Showcase({
   items,
   featured,
+  stars,
 }: {
   items: ShowcaseEntry[];
   /** Curated slugs, already filtered to ones that exist — see lib/featured.ts. */
   featured: string[];
+  /** Live GitHub star count, or `null` if the fetch failed — see lib/github-stars.ts. */
+  stars?: number | null;
 }) {
   const [filter, setFilterState] = useState<Filter>("all");
   const [category, setCategoryState] = useState<string | null>(null);
@@ -273,14 +276,20 @@ export function Showcase({
         Skip to components
       </a>
 
-      <header className="grid gap-10 pt-20 sm:pt-28 lg:grid-cols-[minmax(0,1fr)_minmax(0,28rem)] lg:items-end lg:gap-16">
+      {/* Two-column split waits for xl, not lg — the persistent sidebar
+          (site-shell.tsx) goes static at exactly lg (1024), and splitting the
+          header at the same breakpoint left the headline column squeezed to
+          ~160px there (one word per line, "Star on GitHub" wrapping). At
+          1024 the header now stays a single stacked column with the full
+          main-column width to itself. */}
+      <header className="grid gap-10 pt-20 sm:pt-28 xl:grid-cols-[minmax(0,1fr)_minmax(0,28rem)] xl:items-end xl:gap-16">
         <div>
           <div className="flex items-center justify-between gap-3">
             <p className="font-mono text-xs uppercase tracking-[0.18em] text-muted">
               ns-ui
             </p>
             <div className="flex items-center gap-3">
-              <GitHubStarButton />
+              <GitHubStarButton stars={stars} />
               <ThemeToggle />
             </div>
           </div>
@@ -454,7 +463,7 @@ export function Showcase({
           repeated animated treatment would start reading as an ad. */}
       <div className="mt-24 flex flex-col items-center gap-3 border-t border-border pt-14 text-center">
         <p className="text-sm text-muted">If any of this was useful, a star helps others find it.</p>
-        <GitHubStarButton variant="quiet" />
+        <GitHubStarButton variant="quiet" stars={stars} />
       </div>
 
       <div className="mt-14 flex flex-col items-center border-t border-border pt-14 text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import registry from "@/registry.json";
 import { loadUseWhen } from "@/lib/use-when";
 import order from "@/lib/component-order.json";
 import { FEATURED } from "@/lib/featured";
+import { getStarCount } from "@/lib/github-stars";
 import { Showcase, type ShowcaseEntry } from "./_components/showcase";
 
 // Newest first. `component-order.json` is the slug list sorted by git creation
@@ -66,6 +67,7 @@ const items: ShowcaseEntry[] = registry.items
 
 const featured = [...featuredOrder.keys()];
 
-export default function Home() {
-  return <Showcase items={items} featured={featured} />;
+export default async function Home() {
+  const stars = await getStarCount();
+  return <Showcase items={items} featured={featured} stars={stars} />;
 }

--- a/app/writing/[slug]/page.tsx
+++ b/app/writing/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { loadWritingPost, loadWritingPosts } from "@/lib/writing";
+import { getStarCount } from "@/lib/github-stars";
 import { PostBody } from "../_components/post-body";
 import { ThemeToggle } from "../../_components/theme-toggle";
 import { GitHubStarButton } from "../../_components/github-star-button";
@@ -49,6 +50,7 @@ export default async function WritingPostPage({
   const { slug } = await params;
   const post = loadWritingPost(slug);
   if (!post) notFound();
+  const stars = await getStarCount();
 
   return (
     <main className="mx-auto w-full max-w-2xl px-6 pb-32 sm:px-10">
@@ -88,7 +90,7 @@ export default async function WritingPostPage({
         >
           Back to the catalog
         </Link>
-        <GitHubStarButton variant="quiet" />
+        <GitHubStarButton variant="quiet" stars={stars} />
       </div>
     </main>
   );

--- a/lib/github-stars.ts
+++ b/lib/github-stars.ts
@@ -1,0 +1,27 @@
+const REPO_API_URL = "https://api.github.com/repos/nikolas-sapa/ns-ui";
+
+/**
+ * Live star count for the header CTA. ISR-cached for an hour so this is one
+ * request per hour total, not one per visitor — the unauthenticated GitHub
+ * API is rate-limited to 60 requests/hour/IP, and there's no token here (the
+ * repo is public, this stays anonymous).
+ *
+ * Every failure mode — network error, non-200, rate-limit, a body without the
+ * field it expects — collapses to `null`. The caller renders the button
+ * exactly as it does with no count in that case, so a GitHub outage on launch
+ * day degrades silently instead of breaking the homepage.
+ */
+export async function getStarCount(): Promise<number | null> {
+  try {
+    const res = await fetch(REPO_API_URL, {
+      headers: { "User-Agent": "ns-ui" },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return null;
+    const data: unknown = await res.json();
+    const count = (data as { stargazers_count?: unknown })?.stargazers_count;
+    return typeof count === "number" ? count : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 1. Live star count

`lib/github-stars.ts` reads `stargazers_count` with `next: { revalidate: 3600 }`.

**Why server-side and not a client fetch:** the unauthenticated GitHub API allows 60 requests/hour/IP and there is no token here. ISR makes this one request per hour in total instead of one per visitor, and it means no loading state and no layout shift in the hero on launch day. Sends a `User-Agent`, which GitHub wants and without which an anonymous fetch can 403.

Fetched in the server components (`app/page.tsx`, `app/writing/[slug]/page.tsx`) and threaded down as a prop, because `showcase.tsx` is `"use client"` and cannot be async. The count is in the initial HTML.

**Failure is invisible by construction.** Network error, non-ok, rate-limit, or a body missing the field all collapse to `null`; with `null` the button renders exactly as it does today, no divider and no reserved width. A GitHub outage on launch day must not break the page every post links to. `aria-label` carries the count only when there is one, so there is no "null stars" announcement.

Build output confirms `/` stays **Static** with a 1h revalidate rather than becoming dynamic.

## 2. Anchor-scroll offset

The card carried `scroll-mt-24` but had **no `id`**, and nothing in the repo ever built a `#name` link to one. The offset was dead CSS guarding a feature that did not exist, which is worth knowing since it was previously reported (by me) as a live bug.

Added `id={entry.name}` to make card anchors reachable, then fixed the offset properly rather than with a larger magic number: the sticky bar writes its measured `offsetHeight` to `--filter-bar-h` via a `ResizeObserver` (recomputed on chip wrap and on the Clear button appearing/disappearing), and the card derives `scroll-margin-top` from it with a `6rem` fallback for before-JS. Measured heights: 125px at 1440, 159px at 1024.

## 3. The 1024 squeeze

Root cause: the sidebar goes static at `lg` (1024) and the hero's two-column split *also* switched at `lg`. At exactly 1024 the headline column collapsed to roughly 160px, giving one word per line with the CTA wrapping mid-label.

Moved the header's `grid-cols`, `items` and `gap` to `xl:`. The sidebar breakpoint is deliberately untouched: moving it too would trade the squeeze for a hamburger drawer at laptop width, which is worse, and would obscure which change fixed what.

Headline font size unchanged; the width recovered from stacking was sufficient.

## Verification
Typecheck exit 0. Production build exit 0. Screenshots reviewed at 768, 1024, 1280 and 1440 plus light theme. Star count confirmed rendering (`Star on GitHub | 10`, `aria-label="Star on GitHub, 10 stars"`), CTA height 36px single-line at both 1024 and 1440, and `--filter-bar-h` confirmed measuring live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)