### PR TITLE
perf: make preview routes cacheable, fix the components that jam the main thread

### DIFF
--- a/app/_components/featured-card.tsx
+++ b/app/_components/featured-card.tsx
@@ -65,7 +65,8 @@ export function FeaturedCard({
     return () => ro.disconnect();
   }, []);
 
-  const src = `/preview/${entry.name}?embed=1&autoplay=1`;
+  // The CDN-cacheable path form of `?embed=1&autoplay=1` — see the embed route.
+  const src = `/preview/${entry.name}/embed`;
 
   return (
     <article className="group relative flex flex-col">

--- a/app/_components/preview-card.tsx
+++ b/app/_components/preview-card.tsx
@@ -188,14 +188,15 @@ export function PreviewCard({
         {mounted ? (
           <iframe
             ref={frameRef}
-            // `?embed=1` only makes the demo inert inside the frame — see the
-            // preview route. The page it renders is otherwise identical.
-            // `&autoplay=1` additionally runs the shared autoplay driver, so
-            // components that only wake on input (hover, press, drag, scroll)
-            // demonstrate themselves in the card instead of showing a still
+            // `/embed` is `/preview/<name>?embed=1&autoplay=1` with both flags
+            // baked into the path: the demo is inert, and the shared autoplay
+            // driver runs so components that only wake on input (hover, press,
+            // drag, scroll) demonstrate themselves instead of showing a still
             // frame. Components without an `autoplay` descriptor in their
-            // meta.json are unaffected.
-            src={`/preview/${entry.name}?embed=1&autoplay=1`}
+            // meta.json are unaffected. The path form exists because reading
+            // `searchParams` made the query form uncacheable — every card frame
+            // was a function invocation. See the embed route for the detail.
+            src={`/preview/${entry.name}/embed`}
             title={`${entry.title} preview`}
             loading="lazy"
             tabIndex={-1}

--- a/app/_components/site-analytics.tsx
+++ b/app/_components/site-analytics.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
+
+/**
+ * Analytics, minus the copies every card thumbnail was loading.
+ *
+ * The root layout wraps every route, and a catalog card renders
+ * `/preview/<name>/embed` inside an iframe — so each mounted card booted its
+ * own Analytics *and* Speed Insights. Measured on the live homepage: both
+ * scripts fetched 5x on a single load (once for the page, once per frame), 12
+ * on a tall viewport. Beyond the wasted requests that inflates every pageview
+ * and vitals sample by the number of visible cards, which quietly corrupts the
+ * numbers this site would use to judge a fix like this one.
+ *
+ * A frame is any document that is not the top-level one, so `window.top` is
+ * the whole test — no route list to keep in sync, and it covers the playground
+ * frame and the featured-card frame too.
+ *
+ * Gated behind an effect rather than read during render because the server has
+ * no `window`: rendering the scripts on the server and dropping them on the
+ * client is a hydration mismatch. Both components are client-only and emit no
+ * markup, so a mount-tick delay costs nothing.
+ */
+export function SiteAnalytics() {
+  const [top, setTop] = useState(false);
+
+  useEffect(() => {
+    setTop(window.self === window.top);
+  }, []);
+
+  if (!top) return null;
+
+  return (
+    <>
+      <Analytics />
+      <SpeedInsights />
+    </>
+  );
+}

--- a/app/_components/site-shell.tsx
+++ b/app/_components/site-shell.tsx
@@ -10,14 +10,19 @@ import type { NavGroup } from "@/lib/nav-data";
  * the quality gate:
  *
  * `/preview/<name>` (the BARE route, no `/play`) is what `scripts/verify.ts`
- * and `scripts/record.ts` screenshot, and what every catalog card and the
- * playground embed in an iframe. It must stay a naked component page — the
- * gate grabs "the first visible interactive element" for its hover/press/focus
- * diff, and a sidebar full of links would hand it a nav link instead. So that
- * one shape renders children with no chrome at all.
+ * and `scripts/record.ts` screenshot, and what the playground embeds in an
+ * iframe. `/preview/<name>/embed` is the cacheable card thumbnail every catalog
+ * and featured card loads. Both must stay naked component pages — the gate
+ * grabs "the first visible interactive element" for its hover/press/focus diff,
+ * and a sidebar full of links would hand it a nav link instead. So those two
+ * shapes render children with no chrome at all.
+ *
+ * `/embed` has to be listed explicitly: it is a deeper path, so the original
+ * single-segment pattern rejected it and every card rendered the full sidebar
+ * inside its own iframe (caught by screenshot, after the DOM check passed).
  */
 const isBarePreview = (pathname: string) =>
-  /^\/preview\/[^/]+$/.test(pathname);
+  /^\/preview\/[^/]+(?:\/embed)?$/.test(pathname);
 
 const LINK =
   "block truncate rounded-sm px-2 py-1 text-sm outline-none transition-colors hover:bg-surface hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent motion-reduce:transition-none";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from "next";
-import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import { ThemeSync } from "./_components/theme-sync";
+import { SiteAnalytics } from "./_components/site-analytics";
 import { SiteShell } from "./_components/site-shell";
 import { NO_FLASH_SCRIPT } from "@/lib/theme";
 import { navGroups } from "@/lib/nav-data";
@@ -65,9 +64,9 @@ export default function RootLayout({
             client component only because it needs the active pathname. */}
         <SiteShell groups={navGroups()}>{children}</SiteShell>
         {/* Vercel Web Analytics and Speed Insights. Both no-op outside a
-            Vercel deployment, so local dev is unaffected. */}
-        <Analytics />
-        <SpeedInsights />
+            Vercel deployment, so local dev is unaffected. Skipped inside card
+            iframes — see the component. */}
+        <SiteAnalytics />
       </body>
     </html>
   );

--- a/app/preview/[name]/embed/page.tsx
+++ b/app/preview/[name]/embed/page.tsx
@@ -1,0 +1,56 @@
+import { notFound } from "next/navigation";
+import { demos } from "@/registry/index";
+import autoplayMap from "@/lib/autoplay.generated.json";
+import { parseAutoplay } from "@/lib/autoplay";
+import { AutoplayDriver } from "../autoplay-driver";
+
+/**
+ * The card thumbnail route — what every catalog and featured card loads in its
+ * iframe.
+ *
+ * It exists only to be *cacheable*. The sibling `/preview/<name>` renders the
+ * identical thing for `?embed=1&autoplay=1`, but reading `searchParams` makes
+ * that route fully dynamic: it never enters the prerender manifest, so every
+ * card frame was a function invocation serving `no-store` (measured:
+ * `x-vercel-cache: MISS` on every one, ~4-12 of them per homepage view). Same
+ * markup with the two flags baked into the path instead of the query string
+ * prerenders and serves from the CDN.
+ *
+ * `/preview/<name>` is deliberately left untouched — `scripts/verify.ts` and
+ * `scripts/record.ts` screenshot it directly, and `?embed=1&interactive=1`
+ * (the playground frame) still needs the dynamic variant.
+ *
+ * Kept in lockstep with the sibling by hand: it is five lines of JSX, and the
+ * shared-component indirection costs more than it saves. The invariant is that
+ * a card and the reference page render the same DOM — if that drifts, the
+ * screenshot gate catches it.
+ */
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  // Empty: the 218 demos are client components that have never been exercised
+  // by the build, so prerendering all of them at once is a build-time risk for
+  // no runtime gain. Declaring the function at all is what moves this route out
+  // of the always-dynamic bucket and into ISR — the first request for a slug
+  // renders it, every later one is a CDN hit until `revalidate` expires.
+  return [];
+}
+
+export default async function EmbedPreviewPage({
+  params,
+}: {
+  params: Promise<{ name: string }>;
+}) {
+  const { name } = await params;
+  const Demo = demos[name];
+  if (!Demo) notFound();
+
+  const spec = parseAutoplay((autoplayMap as Record<string, unknown>)[name]);
+
+  return (
+    <div className="min-h-screen" inert data-autoplay-root={spec ? "" : undefined}>
+      <Demo />
+      {spec ? <AutoplayDriver spec={spec} /> : null}
+    </div>
+  );
+}

--- a/app/preview/[name]/play/page.tsx
+++ b/app/preview/[name]/play/page.tsx
@@ -40,6 +40,21 @@ export async function generateMetadata({
   return { title, description: item.description };
 }
 
+/**
+ * Declaring this at all is what moves the route out of the always-dynamic
+ * bucket and into ISR. Without it the playground served `no-store` and every
+ * visit was a function invocation — and because each catalog card links here,
+ * Next prefetches the route for every card near the viewport, so one homepage
+ * load fired ~38 uncached renders (measured). The list is empty on purpose:
+ * prerendering 218 pages at build buys nothing over caching the first request
+ * for each, and costs build time. `revalidate` below does the rest.
+ */
+export function generateStaticParams() {
+  return [];
+}
+
+export const revalidate = 3600;
+
 /** The lead sentence carries the component's job; the rest is build detail. */
 const firstSentence = (text: string) => text.split(/(?<=\.)\s/, 1)[0] ?? text;
 

--- a/docs/perf-audit-2026-07.md
+++ b/docs/perf-audit-2026-07.md
@@ -29,7 +29,27 @@ The main thread stayed ~72% blocked **indefinitely**, with the page idle and
 untouched. That is the "slow": the page paints quickly and then never becomes
 responsive — scrolling stutters and every interaction lands late.
 
-## Cause 1 — five components burn 96% of the CPU
+## Read this before trusting any number below
+
+Total Blocking Time on this hardware is dominated by **machine state**, not by
+the page. The same unmodified component measured 5606ms while other agents' dev
+servers and builds were running (load average 13-18) and **32ms** on the same
+production URL once the machine was quiet (load ~3). That is a 175x swing with
+zero code change.
+
+Consequences, and they are not small:
+
+- Every absolute TBT figure below is only meaningful next to a control measured
+  in the same minute. Where a control is not quoted, treat the number as a
+  ranking signal at best.
+- The per-component "before -> after" wins reported further down were measured
+  back-to-back under load. They are real *under CPU contention* — which is
+  exactly the condition a visitor on a mid-tier laptop is in, and the condition
+  the original complaint came from — but they do **not** reproduce on an idle
+  machine, where most of these components already measure near zero.
+- The headline homepage number did **not** improve. See below.
+
+## Cause 1 — five components burn 96% of the CPU *under contention*
 
 All 222 components were profiled individually at
 `/preview/<name>?embed=1&autoplay=1` (8s window, 3s after load).
@@ -149,6 +169,55 @@ are comparable: `scarp-horizon` 1025 vs 1153, `ascii-dither-media` 29 vs 14,
   three runs each, with tight variance. 23 lines of added state for no gain is
   a bad trade. It remains the worst component in the library at ~4.9s and is
   the obvious next piece of work.
+### Correction: the homepage did not improve
+
+The `-12%` homepage figure first recorded here (7503ms -> 6634ms) did not
+survive. Re-measured on a quiet machine, three interleaved runs each:
+
+    production  steady = 5915 / 6249 / 6290 ms
+    with fixes  steady = 6121 / 6101 / 6043 ms
+
+That is run-to-run variance, not an improvement. **The shipped component work
+does not measurably speed up the homepage.** It was worth finding out why.
+
+## Cause 1b — what actually blocks the homepage: live scaled iframes
+
+A sequence of ablations on the same build, same machine, back to back:
+
+| homepage variant | steady-state TBT / 10s |
+| --- | --- |
+| as shipped (4 featured frames mount, 2 visible) | ~4400-6100ms |
+| catalog card iframes disabled | unchanged (~6300ms) |
+| **all featured iframes disabled** | **0ms** (3/3 runs) |
+| featured frames capped to 2 instead of 4 | unchanged (~4600ms) |
+| featured frames with autoplay off | unchanged (~5000ms) |
+| featured frames unscaled (`scale(1)`, card clips) | ~2900ms |
+
+And, measured individually against the same local build, each of the four
+featured components scores **0ms in isolation** at a full 1440x900 viewport.
+
+So the cost is not the components, not the catalog, not the host page, not
+autoplay, and not the number of frames past the first couple. It is inherent to
+the design the homepage copy advertises — *"every card below is the real
+component running live"* — specifically **a continuously-repainting 1440x900
+iframe being CSS-scaled to ~26% in the parent document**. Roughly 40% of it is
+the scale transform; the rest is simply having live animating documents
+composited into the page.
+
+Nothing in this PR changes that, and no per-component optimization can. The
+levers that would are all product decisions:
+
+- render a poster frame (static image or short video) and only go live on hover
+  or click;
+- size the iframe to its displayed size instead of 1440x900 (cheap, but breaks
+  the viewport-fidelity invariant `preview-card.tsx` exists to protect);
+- keep fewer featured cards above the fold.
+
+Recommended next step: measure a poster-frame prototype for the featured rail
+before writing any more component-level optimizations.
+
+### On the components anyway
+
 - **particle-hero is not a perf bug** and should never have been on this list —
   its 6511ms came from the contended parallel sweep. Its motion is already
   shader-side and `getComputedStyle` runs only on mount. Its measurements swing
@@ -208,6 +277,15 @@ Two process notes that cost real time here:
   throttled browsers at once inflated `particle-hero` roughly 5x and sent an
   agent off to fix a component that was not broken. Re-measure any candidate
   serially before acting on its number.
+- **Check the machine before believing a profile.** `uptime` first. Under load
+  average 13-18 this codebase profiled 175x worse than at load 3, and that noise
+  is what drove most of the component work here. An A/B is only valid measured
+  back-to-back in the same conditions, and an absolute number without a control
+  measured beside it is not evidence.
+- **Ablate before optimizing.** Deleting the suspected cost (here: rendering the
+  featured iframes not at all) took ten minutes and would have redirected the
+  entire effort on day one. Five agents optimizing five components never had a
+  chance to answer "is it the components at all?" — only turning them off did.
 - **Every DOM assertion can pass while the page is visibly wrong.** The sidebar
   regression survived correct `src` attributes, 200 responses, cache HITs and a
   clean typecheck. It took one screenshot to see. When a change alters what

--- a/docs/perf-audit-2026-07.md
+++ b/docs/perf-audit-2026-07.md
@@ -1,0 +1,214 @@
+# Performance audit — July 2026
+
+Triggered by a report that the site felt slow. Everything below is measured, not
+inferred. Method: Playwright, Chromium, `Emulation.setCPUThrottlingRate` rate 4
+(mid-tier laptop), viewport 1440x900, against production
+(`design.helpmarq.com`) unless stated.
+
+## The complaint was not about loading
+
+Loading was already fine. On a warm CDN hit the homepage does:
+
+| metric | value |
+| --- | --- |
+| TTFB (cache HIT) | 174ms |
+| DOMContentLoaded | 303ms |
+| FCP / LCP | 492ms / 572ms |
+| HTML on the wire (brotli) | 97KB (843KB decompressed) |
+| initial JS (brotli) | ~225KB across 12 chunks |
+
+What was wrong is what happens *after* the page loads:
+
+| window (no scroll, no input) | Total Blocking Time |
+| --- | --- |
+| 0-5s (boot) | 2384ms |
+| 5-15s | 7367ms |
+| **15-25s (steady state)** | **7209ms** |
+
+The main thread stayed ~72% blocked **indefinitely**, with the page idle and
+untouched. That is the "slow": the page paints quickly and then never becomes
+responsive — scrolling stutters and every interaction lands late.
+
+## Cause 1 — five components burn 96% of the CPU
+
+All 222 components were profiled individually at
+`/preview/<name>?embed=1&autoplay=1` (8s window, 3s after load).
+
+- **205 of 222 measure exactly 0ms.**
+- 7 exceed 200ms.
+- The top 5 account for **96%** of the library's total blocking time.
+
+The sweep ran 4 browsers in parallel, which inflates absolutes through CPU
+contention, so the top 5 were re-measured **serially** against production. Both
+columns below; the serial column is the one to trust.
+
+| component | TBT / 8s (serial) | TBT / 8s (parallel sweep) |
+| --- | --- | --- |
+| frost-scrub | **6231ms** | 8219ms |
+| solari-flap | **5043ms** | 4895ms |
+| chroma-tide | **4432ms** | 4369ms |
+| glyph-tide | **4146ms** | 3495ms |
+| particle-hero | **1344ms** | 6511ms |
+| scarp-horizon | *(not re-run)* | 551ms |
+
+The sweep's ranking held for four of five. `particle-hero` was the exception —
+inflated roughly 5x by contention, and at 1344ms it is the mildest of the group,
+doing largely legitimate shader-side work rather than thrashing. It was left
+alone. Treat any single-number claim from a parallel sweep as a ranking signal
+only.
+
+`frost-scrub` alone pegs the main thread at ~100%. `glyph-tide` is the **first
+card on the homepage**, so the worst-feeling frame mounts first.
+
+The shared pathology: each is a full-viewport canvas doing per-pixel or
+per-cell work every frame — `getImageData`/`putImageData` loops, per-cell
+`fillText`, per-frame `getComputedStyle` — sized to the 1440x900 iframe even
+though the card displays it CSS-scaled to roughly 380px wide.
+
+This is a handful of component bugs, not an architectural problem. The iframe
+architecture (`preview-card.tsx`) is sound: 205 components run in it for free.
+
+## Cause 2 — every preview route was uncacheable
+
+`app/preview/[name]/page.tsx` awaited `searchParams`, which makes the route
+fully dynamic. Neither it nor `play` appeared in `.next/prerender-manifest.json`
+at all — only `/writing/[slug]` (the one route with `generateStaticParams`) was
+cached. Both served:
+
+    cache-control: private, no-cache, no-store, max-age=0, must-revalidate
+    x-vercel-cache: MISS        (on every request, always)
+
+Per single homepage load that meant:
+
+- 4-12 uncached function invocations for the card iframes, and
+- ~38 more for `/preview/<name>/play`, because each card title is a `next/link`
+  and Next prefetches every link near the viewport (measured: 19 distinct play
+  routes, requested twice each).
+
+So one visitor triggered roughly 50 uncached SSR renders, none of which could be
+shared with the next visitor. The function region is `iad1` while the edge is
+`fra1`, so each one also crossed the Atlantic.
+
+## Cause 3 — analytics ran once per card
+
+The root layout wraps every route, and a card renders a preview route inside an
+iframe, so each mounted card booted its own `@vercel/analytics` **and**
+`@vercel/speed-insights`. Measured on the live homepage: both scripts fetched
+**5x** on a single load. Besides the wasted requests, this inflates every
+pageview and vitals sample by the number of visible cards.
+
+## Fixes applied
+
+1. **New `app/preview/[name]/embed` route.** Same markup as
+   `?embed=1&autoplay=1` with the flags in the path instead of the query string,
+   so it prerenders. `preview-card.tsx` and `featured-card.tsx` now point at it.
+   `/preview/[name]` is untouched — `verify.ts`/`record.ts` screenshot it, and
+   `?embed=1&interactive=1` (the playground frame) still needs the dynamic form.
+2. **`generateStaticParams` + `revalidate` on `/preview/[name]/play`.**
+   Declaring the function at all is what moves a route out of the always-dynamic
+   bucket. Both new routes return an empty param list on purpose: prerendering
+   218 client-component pages at build buys nothing over caching the first
+   request for each, and avoids a build-time risk on demos the build has never
+   exercised.
+3. **`SiteAnalytics`** — mounts Analytics/SpeedInsights only when
+   `window.self === window.top`, so frames skip them.
+4. **`SiteShell` now treats `/preview/<name>/embed` as a bare preview.** The
+   original `isBarePreview` pattern only matched a single path segment, so the
+   deeper `/embed` path fell through and every card rendered the whole site
+   sidebar inside its own iframe. Every DOM assertion still passed — correct
+   iframe `src`, 200s, cache HITs — and it was only caught by looking at a
+   screenshot. It also silently corrupted a round of measurements, because a
+   demo squeezed next to a sidebar does far less work.
+
+5. **Three of five components were optimized; one was reverted, one was a wash.**
+
+Measured with the *same* harness on both sides (rate-4 CPU throttle, 8s window
+3s after load) — production for "before", a local production build for "after".
+Three untouched components were measured on both to prove the two environments
+are comparable: `scarp-horizon` 1025 vs 1153, `ascii-dither-media` 29 vs 14,
+`torus-render` 0 vs 0. Without that control the numbers would be worthless.
+
+| component | before | after | |
+| --- | --- | --- | --- |
+| frost-scrub | 5606ms | **382ms** | -93% |
+| chroma-tide | 2571ms | **1999ms** | -22% |
+| glyph-tide | 4585ms | **3658ms** | -20% |
+| solari-flap | 4908ms | 4977ms | reverted |
+| particle-hero | 1584ms | 2088ms | unmeasurable |
+
+- **frost-scrub** was the real prize and the diagnosis had been wrong: the
+  per-pixel `getImageData` loops run once in setup, not per frame. The cost was
+  the *fragment shader* (15 texture samples per pixel) running at the full
+  1440x900 backing store — for a thumbnail displayed at ~380px. The iframe
+  cannot see the parent's CSS transform, so `clientWidth` still reports 1440.
+  Capping the backing-store dpr to 0.6 *only* when the card marker
+  `[data-autoplay-root]` is present fixes it; the reference page that
+  `verify.ts` screenshots is byte-identical to before.
+- **solari-flap was reverted.** The hypothesis (skip the forced reflow when a
+  cell is already settled) was sound but bought nothing: 4908ms -> 4977ms across
+  three runs each, with tight variance. 23 lines of added state for no gain is
+  a bad trade. It remains the worst component in the library at ~4.9s and is
+  the obvious next piece of work.
+- **particle-hero is not a perf bug** and should never have been on this list —
+  its 6511ms came from the contended parallel sweep. Its motion is already
+  shader-side and `getComputedStyle` runs only on mount. Its measurements swing
+  from 193ms to 3252ms run to run (particle seeds are `Math.random()` per
+  mount), so no change is measurable at this precision. The one edit kept —
+  reusing a scratch `THREE.Vector2` instead of allocating one per frame — is
+  behaviour-identical and removes an allocation, so it is kept on correctness
+  grounds, not on a claimed speedup.
+
+Verified against a local production build and server:
+
+| route | before | after |
+| --- | --- | --- |
+| `/preview/<name>/embed` | *(did not exist)* | `● SSG`, `x-nextjs-cache: HIT`, `s-maxage=3600` |
+| `/preview/<name>/play` | `ƒ` dynamic, `no-store`, MISS | `● SSG`, `x-nextjs-cache: HIT`, `s-maxage=3600` |
+
+Unknown slugs still 404, and `/preview/<name>?embed=1&autoplay=1` still returns
+200.
+
+## Deliberately not done
+
+- **The inline RSC payload.** The homepage serializes the whole 222-item catalog
+  into the HTML for the client-side `Showcase`. Decoded field sizes: `prose`
+  80,997B, `description` 52,561B, `tags` 18,288B — ~152KB of the ~178KB payload.
+
+  `prose` is the tempting target: 81KB, and `grep -rn '\.prose\b' app/ lib/`
+  finds exactly one consumer, the search haystack builder in
+  `showcase.tsx:180-191`. It is never rendered. But it cannot simply be replaced
+  by a precomputed haystack, because a haystack *contains* the prose text plus
+  the title/description/tags already shipped for rendering — that trades 81KB
+  for something larger. Actually shrinking this means either dropping prose from
+  the search corpus (a search-quality decision, not a perf fix) or building a
+  compact token index. Left alone deliberately; the number is recorded here so
+  the trade is a choice rather than an oversight.
+
+  Note this is a parse cost, not a bandwidth one: 843KB of HTML compresses to
+  97KB brotli on the wire.
+- **`regions: ["fra1"]`.** The edge is Frankfurt and the function is US East.
+  Setting this needs a `vercel.json` and changes deploy behaviour for every
+  route, so it is an owner decision. With the routes now CDN-cached it also
+  matters much less.
+- **`MOUNT_CAP = 12`** (`showcase.tsx:48`) still keeps up to 8 off-screen frames
+  live. Lowering it cuts background work but makes cards pop in on scroll — a
+  UX trade, not a free win, and far less relevant now the expensive components
+  are fixed.
+- **The playground's own iframe** (`?embed=1&interactive=1`) is still one dynamic
+  invocation per playground visit. One request per page, left alone.
+- **solari-flap** (~4.9s TBT) is still unfixed — the one attempt did not work
+  and was reverted rather than shipped. It is now the single worst component in
+  the library.
+
+## If you repeat this
+
+Two process notes that cost real time here:
+
+- **A parallel profiling sweep gives you a ranking, not numbers.** Running 4
+  throttled browsers at once inflated `particle-hero` roughly 5x and sent an
+  agent off to fix a component that was not broken. Re-measure any candidate
+  serially before acting on its number.
+- **Every DOM assertion can pass while the page is visibly wrong.** The sidebar
+  regression survived correct `src` attributes, 200 responses, cache HITs and a
+  clean typecheck. It took one screenshot to see. When a change alters what
+  renders, look at it.

--- a/registry/core/particle-hero/component.tsx
+++ b/registry/core/particle-hero/component.tsx
@@ -72,6 +72,9 @@ function parseColor(hex: string): [number, number, number] | null {
 function Particles({ still, visible }: { still: boolean; visible: RefObject<boolean> }) {
   const material = useRef<THREE.ShaderMaterial>(null);
   const pointerInside = useRef(false);
+  // scratch vector for the per-frame ease target — avoids an allocation on
+  // every frame the pointer is inside the canvas
+  const target = useRef(new THREE.Vector2());
   const { viewport, pointer, size, gl } = useThree();
 
   const { positions, seeds } = useMemo(() => {
@@ -140,14 +143,14 @@ function Particles({ still, visible }: { still: boolean; visible: RefObject<bool
     u.uTime.value = clock.elapsedTime;
 
     const inside = pointerInside.current;
-    const target = inside
-      ? new THREE.Vector2((pointer.x * viewport.width) / 2, (pointer.y * viewport.height) / 2)
-      : REST;
+    const t = target.current;
+    if (inside) t.set((pointer.x * viewport.width) / 2, (pointer.y * viewport.height) / 2);
+    else t.copy(REST);
     // exponential ease toward target — dots swell outward as the pointer
     // approaches and relax home behind it
     const c = u.uCursor.value as THREE.Vector2;
-    c.x += (target.x - c.x) * EASE;
-    c.y += (target.y - c.y) * EASE;
+    c.x += (t.x - c.x) * EASE;
+    c.y += (t.y - c.y) * EASE;
     // fade the push in on enter / out on leave so nothing pops
     const p = u.uPush as { value: number };
     p.value += ((inside ? PUSH : 0) - p.value) * EASE;

--- a/registry/core/solari-flap/component.tsx
+++ b/registry/core/solari-flap/component.tsx
@@ -78,8 +78,6 @@ interface CellHandle {
   displayed: string;
   hovering: boolean;
   token: number;
-  /** True once landCell has parked the leaf at its no-transition rest pose. */
-  settled: boolean;
 }
 
 function pick(charset: string): string {
@@ -96,7 +94,6 @@ function makeCell(ch: string): CellHandle {
     displayed: ch,
     hovering: false,
     token: 0,
-    settled: true,
   };
 }
 

--- a/registry/core/solari-flap/component.tsx
+++ b/registry/core/solari-flap/component.tsx
@@ -78,6 +78,8 @@ interface CellHandle {
   displayed: string;
   hovering: boolean;
   token: number;
+  /** True once landCell has parked the leaf at its no-transition rest pose. */
+  settled: boolean;
 }
 
 function pick(charset: string): string {
@@ -94,6 +96,7 @@ function makeCell(ch: string): CellHandle {
     displayed: ch,
     hovering: false,
     token: 0,
+    settled: true,
   };
 }
 

--- a/registry/loud/chroma-tide/component.tsx
+++ b/registry/loud/chroma-tide/component.tsx
@@ -212,20 +212,47 @@ export function ChromaTide({ colors, speed = 1, scale = 1, className = "", style
       gl = null;
     };
 
-    const draw = (nowMs: number) => {
-      if (!gl || !program || w <= 0 || h <= 0) return;
+    // viewport/resolution/scale/palette are each only touched by resize(),
+    // readColors() or a prop change — never by time. WebGL retains uniform
+    // values across draw calls on the same program, so re-sending all six
+    // uniforms and re-setting the viewport on every single animation frame
+    // (this ran continuously, forever) was pure waste on the one uniform
+    // (u_time) that actually changes frame to frame. Setting the static ones
+    // only at their own change points cuts the per-frame GL call count from
+    // 8 to 2.
+    const applyViewportUniforms = () => {
+      if (!gl || !program) return;
       gl.viewport(0, 0, canvas.width, canvas.height);
       gl.uniform2f(uRes, canvas.width, canvas.height);
-      gl.uniform1f(uTime, ((nowMs - startedAt) / 1000) * speedRef.current);
       gl.uniform1f(uScale, scale);
+    };
+    const applyColorUniforms = () => {
+      if (!gl || !program) return;
       gl.uniform3f(uC1, c1[0], c1[1], c1[2]);
       gl.uniform3f(uC2, c2[0], c2[1], c2[2]);
       gl.uniform3f(uC3, c3[0], c3[1], c3[2]);
+    };
+
+    const draw = (nowMs: number) => {
+      if (!gl || !program || w <= 0 || h <= 0) return;
+      gl.uniform1f(uTime, ((nowMs - startedAt) / 1000) * speedRef.current);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
     };
 
+    // The flow field drifts slowly enough that 60 draws/sec buys nothing a
+    // viewer can see over ~30 — it's a calm ambient backdrop, not motion
+    // graphics. Halving the draw rate halves the shader + compositor cost of
+    // an animation that already runs forever with no idle state, which was
+    // the dominant cost of this component. rAF itself still fires every
+    // frame (needed for a smooth stop the instant the tab hides or reduced-
+    // motion flips), it just skips the GL work on alternate frames.
+    const FRAME_INTERVAL_MS = 1000 / 30;
+    let lastDrawMs = 0;
     const loop = (t: number) => {
-      draw(t);
+      if (t - lastDrawMs >= FRAME_INTERVAL_MS) {
+        lastDrawMs = t;
+        draw(t);
+      }
       raf = requestAnimationFrame(loop);
     };
     const wake = () => {
@@ -248,10 +275,12 @@ export function ChromaTide({ colors, speed = 1, scale = 1, className = "", style
       canvas.height = Math.round(h * dpr);
       canvas.style.width = `${w}px`;
       canvas.style.height = `${h}px`;
+      applyViewportUniforms();
       draw(pausedAt || performance.now());
     };
 
     if (!setup()) return; // no WebGL: render nothing, container stays transparent
+    applyColorUniforms();
     const ro = new ResizeObserver(resize);
     ro.observe(container);
     resize();
@@ -282,6 +311,7 @@ export function ChromaTide({ colors, speed = 1, scale = 1, className = "", style
 
     const themeObserver = new MutationObserver(() => {
       readColors();
+      applyColorUniforms();
       if (reduced) draw(pausedAt || performance.now());
     });
     themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
@@ -292,6 +322,7 @@ export function ChromaTide({ colors, speed = 1, scale = 1, className = "", style
     };
     const onRestored = () => {
       if (setup()) {
+        applyColorUniforms();
         resize();
         applyMode();
       }

--- a/registry/loud/frost-scrub/component.tsx
+++ b/registry/loud/frost-scrub/component.tsx
@@ -438,7 +438,22 @@ export function FrostScrub({
       resize = () => {
         const w = Math.max(1, pane.clientWidth);
         const h = Math.max(1, pane.clientHeight);
-        const dpr = Math.min(2, window.devicePixelRatio || 1);
+        // Homepage/catalog cards render this exact DOM inside a fixed
+        // 1440×900 iframe that a *parent-document* CSS transform shrinks to a
+        // ~380px-wide thumbnail — invisible to this document's own layout, so
+        // `pane.clientWidth` still reads 1440 and a dpr-only buffer would
+        // shade the full 5-tap fragment shader at full desktop resolution for
+        // pixels nobody can resolve at thumbnail size. `[data-autoplay-root]`
+        // (see autoplay-driver.tsx) is stamped only on that exact route
+        // shape, so it doubles as the "I'm a card" signal here: cap the
+        // buffer to what a thumbnail can actually show. The real
+        // `/preview/<name>` reference page (what scripts/verify.ts shoots)
+        // never gets this attribute, so its resolution — and look — is
+        // unchanged.
+        const isCard = !!pane.closest("[data-autoplay-root]");
+        const dpr = isCard
+          ? Math.min(0.6, window.devicePixelRatio || 1)
+          : Math.min(2, window.devicePixelRatio || 1);
         canvas.width = Math.max(1, Math.round(w * dpr));
         canvas.height = Math.max(1, Math.round(h * dpr));
         gl.viewport(0, 0, canvas.width, canvas.height);

--- a/registry/loud/glyph-tide/component.tsx
+++ b/registry/loud/glyph-tide/component.tsx
@@ -123,7 +123,10 @@ export function GlyphTide({ cellSize = 12, className = "" }: GlyphTideProps) {
         sized = false;
         return;
       }
-      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      const isCard = !!canvas.closest("[data-autoplay-root]");
+      dpr = isCard
+        ? Math.min(0.6, window.devicePixelRatio || 1)
+        : Math.min(window.devicePixelRatio || 1, 2);
       canvas.width = Math.max(1, Math.round(width * dpr));
       canvas.height = Math.max(1, Math.round(height * dpr));
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);

--- a/registry/loud/glyph-tide/component.tsx
+++ b/registry/loud/glyph-tide/component.tsx
@@ -14,6 +14,17 @@ import { useEffect, useRef } from "react";
 // reads as pushed outward, like dragging a finger through liquid, and settles
 // back on its own once the cursor stops. Canvas 2D, direct-DOM rAF, no React
 // state on the hot path, char+alpha-bucket buffers reused every frame.
+//
+// Pass 1's per-cell field sample is the hot spot: fieldValue() is 7 Math.sin
+// calls, and away from the cursor 6 of its 7 sine arguments only ever depend
+// on x, on y, on (x-y), or on (x+y) individually — never on x and y mixed
+// with different weights. So for the idle (unwarped) grid those 6 terms are
+// hoisted into 1-D tables built once per frame (O(cols+rows) sines) and
+// pass 1 becomes table lookups + adds; only the true xy-cross term
+// (0.29x + 0.24y) and the warp-perturbed cells near the cursor still call
+// fieldValue() directly. Same operand order as fieldValue() throughout, so
+// output is bit-identical. Pass 2 walks only the lit cells bucketed in pass
+// 1 instead of rescanning the full grid once per alpha bucket.
 // ---------------------------------------------------------------------------
 
 const RAMP = " .'`,:-=+*#%@";
@@ -69,13 +80,24 @@ export function GlyphTide({ cellSize = 12, className = "" }: GlyphTideProps) {
     let rows = 0;
     let dpr = 1;
     let charBuf = new Uint8Array(0);
-    let bucketBuf = new Uint8Array(0);
+    // per-bucket lists of lit cell indices, rebuilt each frame in pass 1 and
+    // walked once each in pass 2 — replaces a full grid rescan per bucket
+    const bucketLists: number[][] = Array.from({ length: ALPHA_BUCKETS }, () => []);
     let sized = false;
     let ready = false;
     let disposed = false;
     let raf = 0;
     let last = 0;
     let t = 0;
+
+    // 1-D sine tables for the idle-grid fast path in pass 1 — sized on
+    // resize, refilled every frame in draw() (values depend on t)
+    let sinAx = new Float64Array(0); // sin(x*0.045 + t*0.16), indexed by gx
+    let sinAy = new Float64Array(0); // sin(y*0.05 - t*0.12), indexed by gy
+    let sinAxy = new Float64Array(0); // sin((x-y)*0.03 + t*0.07), indexed by (gx-gy)+rows-1
+    let sinBx = new Float64Array(0); // sin(x*0.13 - t*0.34), indexed by gx
+    let sinBy = new Float64Array(0); // sin(y*0.11 + t*0.27), indexed by gy
+    let sinCxy = new Float64Array(0); // sin((x+y)*0.34 - t*1.05), indexed by gx+gy
 
     const cursor = { x: -1e5, y: -1e5, tx: -1e5, ty: -1e5, energy: 0 };
 
@@ -113,7 +135,12 @@ export function GlyphTide({ cellSize = 12, className = "" }: GlyphTideProps) {
       cols = Math.max(1, Math.floor(width / cellW));
       rows = Math.max(1, Math.floor(height / cellH));
       charBuf = new Uint8Array(cols * rows);
-      bucketBuf = new Uint8Array(cols * rows);
+      sinAx = new Float64Array(cols);
+      sinBx = new Float64Array(cols);
+      sinAy = new Float64Array(rows);
+      sinBy = new Float64Array(rows);
+      sinAxy = new Float64Array(cols + rows - 1);
+      sinCxy = new Float64Array(cols + rows - 1);
       sized = true;
     };
 
@@ -132,18 +159,36 @@ export function GlyphTide({ cellSize = 12, className = "" }: GlyphTideProps) {
       const w = cols * cellW;
       const h = rows * cellH;
       ctx.clearRect(0, 0, w, h);
-      ctx.fillStyle = fg;
 
       const cgx = cursor.x / cellW;
       const cgy = cursor.y / cellH;
       const r2 = WARP_RADIUS * WARP_RADIUS;
       const energy = cursor.energy;
 
+      for (let b = 0; b < ALPHA_BUCKETS; b++) bucketLists[b].length = 0;
+
+      // fill the 1-D tables for this frame's t — same operand order as
+      // fieldValue() so the idle-path sum below is bit-identical to it
+      const rowOff = rows - 1; // offset so (gx-gy) never indexes negative
+      for (let gx = 0; gx < cols; gx++) {
+        sinAx[gx] = Math.sin(gx * 0.045 + t * 0.16);
+        sinBx[gx] = Math.sin(gx * 0.13 - t * 0.34);
+      }
+      for (let gy = 0; gy < rows; gy++) {
+        sinAy[gy] = Math.sin(gy * 0.05 - t * 0.12);
+        sinBy[gy] = Math.sin(gy * 0.11 + t * 0.27);
+      }
+      for (let n = 0; n < cols + rows - 1; n++) {
+        sinAxy[n] = Math.sin((n - rowOff) * 0.03 + t * 0.07); // n-rowOff = gx-gy
+        sinCxy[n] = Math.sin(n * 0.34 - t * 1.05); // n = gx+gy
+      }
+
       let i = 0;
       for (let gy = 0; gy < rows; gy++) {
         for (let gx = 0; gx < cols; gx++, i++) {
           let sx = gx;
           let sy = gy;
+          let warped = false;
           if (energy > 0.002) {
             const dx = gx - cgx;
             const dy = gy - cgy;
@@ -154,9 +199,20 @@ export function GlyphTide({ cellSize = 12, className = "" }: GlyphTideProps) {
               const dist = Math.sqrt(d2) || 1e-4;
               sx = gx + (dx / dist) * push;
               sy = gy + (dy / dist) * push;
+              warped = true;
             }
           }
-          let v = fieldValue(sx, sy, t);
+          let v: number;
+          if (warped) {
+            v = fieldValue(sx, sy, t);
+          } else {
+            // idle grid: gx/gy are integers, so every table lookup below is
+            // exactly the sine term it replaces from fieldValue()
+            const a = sinAx[gx] + sinAy[gy] + sinAxy[gx - gy + rowOff];
+            const b = sinBx[gx] + sinBy[gy];
+            const c = Math.sin(gx * 0.29 + gy * 0.24 + t * 0.85) + sinCxy[gx + gy];
+            v = (a * 0.42 + b * 0.34 + c * 0.24) / 5 + 0.5;
+          }
           v = v < 0 ? 0 : v > 1 ? 1 : v;
           const lum = Math.pow(v, 1.6); // gamma: deepens the floor, crests pop
           const bucket = Math.min(
@@ -164,25 +220,26 @@ export function GlyphTide({ cellSize = 12, className = "" }: GlyphTideProps) {
             Math.floor(lum * ALPHA_BUCKETS)
           );
           const ci = Math.floor(lum * (RAMP.length - 1));
-          bucketBuf[i] = bucket;
-          charBuf[i] = RAMP[ci] === " " ? 0 : ci;
+          charBuf[i] = ci; // ci === 0 is RAMP[0] === " " — skipped below
+          if (ci !== 0) bucketLists[bucket].push(i);
         }
       }
 
-      // one globalAlpha set per bucket instead of per glyph
+      // pass 2 only walks the lit cells collected per bucket above, instead
+      // of rescanning the full grid once per alpha bucket
+      ctx.fillStyle = fg;
       for (let b = 0; b < ALPHA_BUCKETS; b++) {
-        const alpha = 0.18 + (b / (ALPHA_BUCKETS - 1)) * 0.82;
-        ctx.globalAlpha = alpha;
-        let j = 0;
-        for (let gy = 0; gy < rows; gy++) {
-          for (let gx = 0; gx < cols; gx++, j++) {
-            if (charBuf[j] === 0 || bucketBuf[j] !== b) continue;
-            ctx.fillText(
-              RAMP[charBuf[j]],
-              gx * cellW + cellW / 2,
-              gy * cellH + cellH / 2
-            );
-          }
+        const list = bucketLists[b];
+        ctx.globalAlpha = 0.18 + (b / (ALPHA_BUCKETS - 1)) * 0.82;
+        for (let k = 0; k < list.length; k++) {
+          const idx = list[k];
+          const gx = idx % cols;
+          const gy = (idx - gx) / cols;
+          ctx.fillText(
+            RAMP[charBuf[idx]],
+            gx * cellW + cellW / 2,
+            gy * cellH + cellH / 2
+          );
         }
       }
       ctx.globalAlpha = 1;


### PR DESCRIPTION
Reported symptom: the site feels slow.

**Two independent findings. The server-side one is solid and shipped. The client-side one turned out to be architectural, and I am not fixing it unilaterally.**

---

## Finding 1 (fixed): every preview route was uncacheable

`app/preview/[name]` awaited `searchParams`, which makes a route fully dynamic. It and `/play` were absent from the prerender manifest entirely and served `no-store` with `x-vercel-cache: MISS` on **every** request. Since each card title is a prefetched `next/link`, **one homepage visit fired ~50 uncached SSR renders**, each crossing from the `fra1` edge to an `iad1` function.

Also: every iframe inherits the root layout, so both Vercel analytics scripts were fetched **5× per homepage load** — which was inflating your pageview and vitals numbers by the number of visible cards.

| route | before | after |
| --- | --- | --- |
| `/preview/<name>/embed` | *(new)* | `● SSG`, `x-nextjs-cache: HIT`, `s-maxage=3600` |
| `/preview/<name>/play` | `ƒ` dynamic, `no-store`, MISS | `● SSG`, `x-nextjs-cache: HIT`, `s-maxage=3600` |

**Verified by response headers, not by timing**, so none of the measurement caveats below apply to it. Unknown slugs still 404; the original query-string route still returns 200.

---

## Finding 2 (not fixed, needs your call): live scaled iframes are the homepage cost

The homepage main thread is blocked ~60% indefinitely on an idle, untouched page. I originally attributed this to five expensive components and optimized them. **That was wrong**, and the ablations say so plainly — same build, same machine, back to back:

| homepage variant | steady-state TBT / 10s |
| --- | --- |
| as shipped (4 featured frames mount, 2 visible) | ~4400–6100ms |
| catalog card iframes disabled | unchanged |
| **all featured iframes disabled** | **0ms** (3/3 runs) |
| featured capped to 2 frames instead of 4 | unchanged |
| featured with autoplay off | unchanged |
| featured unscaled (`scale(1)`) | ~2900ms |

Each of those four featured components measures **0ms in isolation** at a full 1440×900 viewport.

So it is not the components, the catalog, the host page, autoplay, or the frame count. It is **a continuously-repainting 1440×900 iframe being CSS-scaled to ~26% in the parent** — roughly 40% scale transform, the rest just compositing live animating documents. That is the design the homepage advertises ("every card below is the real component running live"), and no per-component optimization can change it.

Levers, all product decisions and therefore yours:
- poster frame (image/short video) until hover or click;
- size the iframe to its displayed size rather than 1440×900 — cheap, but breaks the viewport-fidelity invariant `preview-card.tsx` exists to protect;
- fewer featured cards above the fold.

I'd measure a poster-frame prototype for the featured rail before anyone writes another component optimization.

---

## Corrections to my own earlier claims

- **The homepage did not improve.** A `-12%` I reported was run-to-run variance. Quiet machine, three interleaved runs each: production 5915/6249/6290ms vs with-fixes 6121/6101/6043ms.
- **The component numbers are load-dependent to the point of being misleading.** Unmodified `frost-scrub` measured 5606ms at load average 13–18 (other agents' builds running) and **32ms** on the same production URL at load ~3 — a 175× swing with no code change. The component wins are real *under CPU contention*, which is the condition the complaint came from, but they don't reproduce on an idle machine.
- **`solari-flap` was reverted**, twice: 4908ms → 4977ms across three runs each. 20+ lines of state for nothing.
- **`particle-hero` was never a perf bug** — its 6511ms came from a contended parallel sweep. Its one retained change is a scratch-vector reuse kept on correctness grounds only.
- **A sidebar regression was introduced and fixed here**: `/embed` is a deeper path than `/preview/<name>`, so `SiteShell` rejected it and every card rendered the full site nav inside its iframe. Every DOM assertion passed — correct `src`, 200s, cache HITs, clean typecheck. Only a screenshot caught it.

## Not done (deliberate)

`regions: ["fra1"]` (needs `vercel.json`, changes deploy behaviour, matters less now routes are cached) · trimming the 81KB `prose` field (one consumer, and a precomputed haystack would be *larger* — real reduction is a search-quality call) · `MOUNT_CAP` (proven not to be the lever).

Full method, the 222-component profile, and the process traps are in `docs/perf-audit-2026-07.md`.