### PR TITLE
Improve saved library with previews, copy, and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Adding a component means creating a folder with
 [CONTRIBUTING.md](CONTRIBUTING.md), and [AGENTS.md](AGENTS.md) if you are an
 agent working inside this repo.
 
+## Saved library
+
+Signed-in users can bookmark components from the catalog. The account's Saved
+view shows live previews, full details, copyable install commands, and private
+folders for organizing saves. See [`docs/saved-library.md`](docs/saved-library.md).
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/app/_components/featured-card.tsx
+++ b/app/_components/featured-card.tsx
@@ -171,6 +171,15 @@ export function FeaturedCard({
         ref={boxRef}
         className="relative aspect-[16/10] w-full overflow-hidden rounded-md border border-border bg-surface transition-colors duration-200 group-hover:border-muted/60 group-has-[a:focus-visible]/focus:ring-2 group-has-[a:focus-visible]/focus:ring-accent group-has-[a:focus-visible]/focus:ring-offset-2 group-has-[a:focus-visible]/focus:ring-offset-background motion-reduce:transition-none"
       >
+        <div className="absolute right-3 top-3 z-20">
+          <SaveButton
+            name={entry.name}
+            saved={saved}
+            authenticated={authenticated}
+            pending={savePending}
+            onToggle={onToggleSave}
+          />
+        </div>
         {/* Flat, non-gradient hover wash — same as preview-card.tsx. Sits
             above the poster/video/iframe layers (explicit z-index), so it
             reads on all three regardless of which is currently showing. */}
@@ -307,13 +316,6 @@ export function FeaturedCard({
           value={installCommand}
           label={`Copy install command for ${entry.name}`}
           className="relative z-20"
-        />
-        <SaveButton
-          name={entry.name}
-          saved={saved}
-          authenticated={authenticated}
-          pending={savePending}
-          onToggle={onToggleSave}
         />
       </div>
     </article>

--- a/app/_components/preview-card.tsx
+++ b/app/_components/preview-card.tsx
@@ -250,6 +250,15 @@ export function PreviewCard({
             }}
           />
         ) : null}
+        <div className="absolute right-3 top-3 z-20">
+          <SaveButton
+            name={entry.name}
+            saved={saved}
+            authenticated={authenticated}
+            pending={savePending}
+            onToggle={onToggleSave}
+          />
+        </div>
       </div>
 
       <div className="mt-3 flex items-start gap-3">
@@ -305,13 +314,6 @@ export function PreviewCard({
           value={installCommand}
           label={`Copy install command for ${entry.name}`}
           className="relative z-20 -mt-1"
-        />
-        <SaveButton
-          name={entry.name}
-          saved={saved}
-          authenticated={authenticated}
-          pending={savePending}
-          onToggle={onToggleSave}
         />
       </div>
     </article>

--- a/app/_components/save-button.tsx
+++ b/app/_components/save-button.tsx
@@ -32,9 +32,18 @@ export function SaveButton({
         }
         onToggle(name);
       }}
-      className="relative z-20 shrink-0 rounded-sm border border-border bg-surface px-2.5 py-1.5 text-xs text-foreground outline-none transition-colors hover:border-muted focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-wait disabled:opacity-60"
+      className="relative z-20 inline-flex size-8 shrink-0 items-center justify-center rounded-sm border border-border bg-surface/90 text-foreground outline-none backdrop-blur-sm transition-colors hover:border-muted focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-wait disabled:opacity-60"
     >
-      {pending ? "Saving…" : label}
+      <BookmarkIcon filled={saved} />
+      <span className="sr-only">{pending ? "Saving…" : label}</span>
     </button>
+  );
+}
+
+function BookmarkIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg viewBox="0 0 16 16" className="size-4" fill={filled ? "currentColor" : "none"} stroke="currentColor" strokeWidth="1.25" aria-hidden>
+      <path d="M4 2.25h8a.75.75 0 0 1 .75.75v10.25L8 10.75l-4.75 2.5V3a.75.75 0 0 1 .75-.75Z" strokeLinejoin="round" />
+    </svg>
   );
 }

--- a/app/_components/saved-library.tsx
+++ b/app/_components/saved-library.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { CopyButton } from "./copy-button";
+import { REGISTRY_ORIGIN } from "@/lib/registry-origin";
+
+type Folder = { id: string; name: string; slugs: string[] };
+type Item = { name: string; title: string; description: string };
+
+export function SavedLibrary({ items, slugs, initialFolders }: { items: Item[]; slugs: string[]; initialFolders: Folder[] }) {
+  const [folders, setFolders] = useState(initialFolders);
+  const [selected, setSelected] = useState("all");
+  const [pending, setPending] = useState<string | null>(null);
+  const [newFolder, setNewFolder] = useState("");
+  const [error, setError] = useState("");
+  const byName = useMemo(() => new Map(items.map((item) => [item.name, item])), [items]);
+  const folder = folders.find((entry) => entry.id === selected);
+  const visibleSlugs = selected === "all" ? slugs : folder?.slugs ?? [];
+  const visible = visibleSlugs.map((slug) => byName.get(slug)).filter((item): item is Item => item !== undefined);
+
+  async function createFolder(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError("");
+    const name = newFolder.trim();
+    if (!name) return;
+    const response = await fetch("/api/folders", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name }) });
+    const data = (await response.json().catch(() => ({}))) as { id?: string; name?: string; error?: string };
+    if (!response.ok || !data.id || !data.name) {
+      setError(data.error === "folder_exists" ? "That folder already exists." : "Could not create folder.");
+      return;
+    }
+    setFolders((current) => [...current, { id: data.id!, name: data.name!, slugs: [] }]);
+    setSelected(data.id);
+    setNewFolder("");
+  }
+
+  async function move(slug: string, folderId: string | null) {
+    setPending(slug);
+    setError("");
+    const response = await fetch("/api/folders", { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action: "move", slug, folderId }) });
+    if (response.ok) {
+      setFolders((current) => current.map((entry) => ({ ...entry, slugs: entry.slugs.filter((item) => item !== slug).concat(entry.id === folderId ? [slug] : []) })));
+    } else {
+      setError("Could not move this save.");
+    }
+    setPending(null);
+  }
+
+  return (
+    <div className="mt-5">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border pb-4">
+        <button type="button" onClick={() => setSelected("all")} className={`rounded-sm px-2.5 py-1.5 text-xs outline-none focus-visible:ring-2 focus-visible:ring-accent ${selected === "all" ? "bg-foreground text-background" : "border border-border text-muted hover:text-foreground"}`}>All saves <span className="font-mono">{slugs.length}</span></button>
+        {folders.map((entry) => <button key={entry.id} type="button" onClick={() => setSelected(entry.id)} className={`rounded-sm px-2.5 py-1.5 text-xs outline-none focus-visible:ring-2 focus-visible:ring-accent ${selected === entry.id ? "bg-foreground text-background" : "border border-border text-muted hover:text-foreground"}`}>{entry.name} <span className="font-mono">{entry.slugs.length}</span></button>)}
+        <form onSubmit={createFolder} className="ml-auto flex items-center gap-1.5">
+          <label htmlFor="new-folder" className="sr-only">New folder name</label>
+          <input id="new-folder" value={newFolder} onChange={(event) => setNewFolder(event.target.value)} maxLength={40} placeholder="New folder" className="w-28 rounded-sm border border-border bg-background px-2.5 py-1.5 text-xs text-foreground outline-none placeholder:text-muted focus-visible:ring-2 focus-visible:ring-accent" />
+          <button type="submit" className="rounded-sm border border-border px-2.5 py-1.5 text-xs text-foreground outline-none hover:border-muted focus-visible:ring-2 focus-visible:ring-accent">Add</button>
+        </form>
+      </div>
+      {error ? <p role="alert" className="mt-3 text-xs text-[var(--error)]">{error}</p> : null}
+      {visible.length === 0 ? <p className="mt-6 text-sm text-muted">{selected === "all" ? "Nothing saved yet." : "This folder is empty."}</p> : (
+        <ul className="mt-6 grid gap-5 sm:grid-cols-2">
+          {visible.map((item) => {
+            const currentFolder = folders.find((entry) => entry.slugs.includes(item.name));
+            const installCommand = `npx shadcn add ${REGISTRY_ORIGIN}/r/${item.name}.json`;
+            return (
+              <li key={item.name} className="overflow-hidden rounded-md border border-border bg-surface">
+                <Link href={`/components/${item.name}`} className="group block outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent">
+                  <div className="relative aspect-[16/10] overflow-hidden border-b border-border bg-background">
+                    <iframe src={`/preview/${item.name}/embed`} title={`${item.title} preview`} loading="lazy" tabIndex={-1} aria-hidden className="pointer-events-none absolute left-0 top-0 h-[900px] w-[1440px] origin-top-left scale-[0.28] border-0" />
+                    <div aria-hidden className="absolute inset-0 bg-foreground/0 transition-colors group-hover:bg-foreground/[0.04]" />
+                  </div>
+                  <div className="p-3">
+                    <h3 className="text-sm font-semibold tracking-tight text-foreground">{item.title}</h3>
+                    <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted">{item.description}</p>
+                  </div>
+                </Link>
+                <div className="flex items-center gap-2 border-t border-border px-3 py-2">
+                  <label htmlFor={`folder-${item.name}`} className="text-[11px] text-muted">Folder</label>
+                  <select id={`folder-${item.name}`} value={currentFolder?.id ?? ""} disabled={pending === item.name} onChange={(event) => void move(item.name, event.target.value || null)} className="min-w-0 flex-1 rounded-sm border border-border bg-background px-2 py-1 text-xs text-foreground outline-none focus-visible:ring-2 focus-visible:ring-accent">
+                    <option value="">Unfiled</option>
+                    {folders.map((entry) => <option key={entry.id} value={entry.id}>{entry.name}</option>)}
+                  </select>
+                  <CopyButton value={installCommand} label={`Copy install command for ${item.title}`} />
+                  <Link href={`/components/${item.name}`} className="rounded-sm px-2 py-1 text-xs text-muted outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent">Details</Link>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -13,6 +13,7 @@ import { AccountSignOut } from "@/app/_components/account-signout";
 import { AccountProfileForm } from "@/app/_components/account-profile-form";
 import { AccountDelete } from "@/app/_components/account-delete";
 import { AccountHandle } from "@/app/_components/account-handle";
+import { SavedLibrary } from "@/app/_components/saved-library";
 // Same source `app/page.tsx:28` reads to filter FEATURED against what
 // actually exists in the registry (§3's "slug gate") — not a second slug
 // list. A save whose slug no longer resolves degrades silently: it's
@@ -49,10 +50,10 @@ export default async function AccountPage() {
   }
 
   const token = await convexAuthNextjsToken();
-  const [viewer, profile, slugs] = await Promise.all([
+  const [viewer, profile, library] = await Promise.all([
     fetchQuery(api.users.viewer, {}, { token }),
     fetchQuery(api.profiles.mine, {}, { token }),
-    fetchQuery(api.saves.list, {}, { token }),
+    fetchQuery(api.saves.library, {}, { token }),
   ]);
 
   // No `profiles` row yet — §8.3's abandonment case: "a `users` row exists
@@ -82,12 +83,13 @@ export default async function AccountPage() {
     );
   }
 
-  const bookmarks = (slugs ?? [])
+  const slugs = library?.slugs ?? [];
+  const bookmarks = slugs
     .map((slug) => registryItems.get(slug))
     .filter((item): item is { name: string; title: string; description: string } => item !== undefined);
 
   return (
-    <main className="mx-auto flex max-w-md flex-col px-6 py-16">
+    <main className="mx-auto flex max-w-5xl flex-col px-6 py-16 sm:px-10">
       <h1 className="text-xl font-medium text-foreground">Account</h1>
       <div className="mt-6 space-y-1 text-sm">
         {viewer?.displayName ? (
@@ -121,28 +123,8 @@ export default async function AccountPage() {
       </section>
 
       <section className="mt-8">
-        <h2 className="text-sm font-medium text-foreground">
-          Saved ({bookmarks.length})
-        </h2>
-        {bookmarks.length === 0 ? (
-          <p className="mt-3 text-sm text-muted">Nothing saved yet.</p>
-        ) : (
-          <ul className="mt-3 space-y-2">
-            {bookmarks.map((item) => (
-              <li key={item.name}>
-                <Link
-                  href={`/preview/${item.name}`}
-                  className="block rounded-sm border border-border bg-surface px-3 py-2 text-sm text-foreground outline-none transition-colors hover:border-muted focus-visible:ring-2 focus-visible:ring-accent"
-                >
-                  <span className="font-medium">{item.title}</span>
-                  <span className="mt-0.5 block truncate text-xs text-muted">
-                    {item.description}
-                  </span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
+        <h2 className="text-sm font-medium text-foreground">Saved ({bookmarks.length})</h2>
+        <SavedLibrary items={bookmarks} slugs={slugs} initialFolders={library?.folders ?? []} />
       </section>
 
       <div className="mt-10 flex items-center justify-between">

--- a/app/api/folders/route.ts
+++ b/app/api/folders/route.ts
@@ -1,0 +1,76 @@
+import { convexAuthNextjsToken } from "@convex-dev/auth/nextjs/server";
+import { fetchMutation, fetchQuery } from "convex/nextjs";
+import { ConvexError } from "convex/values";
+import { NextResponse, type NextRequest } from "next/server";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+
+export const dynamic = "force-dynamic";
+
+function originIsAllowed(request: NextRequest): boolean {
+  return request.headers.get("origin") === request.nextUrl.origin;
+}
+
+function errorCode(error: unknown): string | null {
+  if (error instanceof ConvexError && typeof error.data === "object" && error.data !== null) {
+    const code = (error.data as { code?: unknown }).code;
+    return typeof code === "string" ? code : null;
+  }
+  return null;
+}
+
+const statuses: Record<string, number> = { invalid_folder_name: 400, folder_exists: 409, too_many_folders: 400 };
+
+export async function GET() {
+  const token = await convexAuthNextjsToken();
+  if (!token) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  const library = await fetchQuery(api.saves.library, {}, { token });
+  if (library === null) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  return NextResponse.json(library);
+}
+
+export async function POST(request: NextRequest) {
+  const token = await convexAuthNextjsToken();
+  if (!token) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  if (!originIsAllowed(request)) return NextResponse.json({ error: "origin_not_allowed" }, { status: 403 });
+  const body = (await request.json().catch(() => null)) as { name?: unknown } | null;
+  if (typeof body?.name !== "string") return NextResponse.json({ error: "invalid_folder_name" }, { status: 400 });
+  try {
+    const folder = await fetchMutation(api.saves.createFolder, { name: body.name }, { token });
+    return NextResponse.json(folder, { status: 201 });
+  } catch (error) {
+    const code = errorCode(error);
+    return NextResponse.json({ error: code ?? "folder_failed" }, { status: statuses[code ?? ""] ?? 400 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const token = await convexAuthNextjsToken();
+  if (!token) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  if (!originIsAllowed(request)) return NextResponse.json({ error: "origin_not_allowed" }, { status: 403 });
+  const body = (await request.json().catch(() => null)) as { action?: unknown; folderId?: unknown; name?: unknown; slug?: unknown } | null;
+  try {
+    if (body?.action === "rename" && typeof body.folderId === "string" && typeof body.name === "string") {
+      await fetchMutation(api.saves.renameFolder, { folderId: body.folderId as Id<"collections">, name: body.name }, { token });
+    } else if (body?.action === "move" && typeof body.slug === "string") {
+      const folderId = body.folderId === null || body.folderId === undefined ? null : body.folderId as Id<"collections">;
+      await fetchMutation(api.saves.moveToFolder, { slug: body.slug, folderId }, { token });
+    } else {
+      return NextResponse.json({ error: "invalid_folder_request" }, { status: 400 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const code = errorCode(error);
+    return NextResponse.json({ error: code ?? "folder_failed" }, { status: statuses[code ?? ""] ?? 400 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const token = await convexAuthNextjsToken();
+  if (!token) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  if (!originIsAllowed(request)) return NextResponse.json({ error: "origin_not_allowed" }, { status: 403 });
+  const body = (await request.json().catch(() => null)) as { folderId?: unknown } | null;
+  if (typeof body?.folderId !== "string") return NextResponse.json({ error: "invalid_folder_request" }, { status: 400 });
+  await fetchMutation(api.saves.deleteFolder, { folderId: body.folderId as Id<"collections"> }, { token });
+  return NextResponse.json({ ok: true });
+}

--- a/convex/saves.ts
+++ b/convex/saves.ts
@@ -83,6 +83,111 @@ export const list = query({
   },
 });
 
+/** The private saved-library view: bare saves plus their optional folders. */
+export const library = query({
+  args: {},
+  returns: v.union(
+    v.object({
+      slugs: v.array(v.string()),
+      folders: v.array(v.object({
+        id: v.id("collections"),
+        name: v.string(),
+        slugs: v.array(v.string()),
+      })),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) return null;
+    const [saves, folders] = await Promise.all([
+      ctx.db.query("saves").withIndex("by_user", (q) => q.eq("userId", userId)).collect(),
+      ctx.db.query("collections").withIndex("by_user", (q) => q.eq("userId", userId)).collect(),
+    ]);
+    return {
+      slugs: saves.map((save) => save.slug),
+      folders: await Promise.all(folders.sort((a, b) => a.createdAt - b.createdAt).map(async (folder) => {
+        const items = await ctx.db.query("collectionItems").withIndex("by_collection", (q) => q.eq("collectionId", folder._id)).collect();
+        return { id: folder._id, name: folder.name, slugs: items.sort((a, b) => a.position - b.position).map((item) => item.slug) };
+      })),
+    };
+  },
+});
+
+export const createFolder = mutation({
+  args: { name: v.string() },
+  returns: v.object({ id: v.id("collections"), name: v.string() }),
+  handler: async (ctx, { name }) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) throw new Error("Not authenticated");
+    const cleanName = name.trim();
+    if (cleanName.length < 1 || cleanName.length > 40) throw new ConvexError({ code: "invalid_folder_name" as const });
+    const existing = await ctx.db.query("collections").withIndex("by_user", (q) => q.eq("userId", userId)).collect();
+    if (existing.some((folder) => folder.name.toLowerCase() === cleanName.toLowerCase())) throw new ConvexError({ code: "folder_exists" as const });
+    if (existing.length >= 30) throw new ConvexError({ code: "too_many_folders" as const });
+    const id = await ctx.db.insert("collections", { userId, name: cleanName, isPublic: false, createdAt: Date.now() });
+    return { id, name: cleanName };
+  },
+});
+
+export const renameFolder = mutation({
+  args: { folderId: v.id("collections"), name: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { folderId, name }) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) throw new Error("Not authenticated");
+    const folder = await ctx.db.get(folderId);
+    if (folder === null || folder.userId !== userId) throw new Error("Not found");
+    const cleanName = name.trim();
+    if (cleanName.length < 1 || cleanName.length > 40) throw new ConvexError({ code: "invalid_folder_name" as const });
+    await ctx.db.patch(folderId, { name: cleanName });
+    return null;
+  },
+});
+
+export const deleteFolder = mutation({
+  args: { folderId: v.id("collections") },
+  returns: v.null(),
+  handler: async (ctx, { folderId }) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) throw new Error("Not authenticated");
+    const folder = await ctx.db.get(folderId);
+    if (folder === null || folder.userId !== userId) throw new Error("Not found");
+    const items = await ctx.db.query("collectionItems").withIndex("by_collection", (q) => q.eq("collectionId", folderId)).collect();
+    for (const item of items) await ctx.db.delete(item._id);
+    await ctx.db.delete(folderId);
+    return null;
+  },
+});
+
+export const moveToFolder = mutation({
+  args: { slug: v.string(), folderId: v.union(v.id("collections"), v.null()) },
+  returns: v.null(),
+  handler: async (ctx, { slug, folderId }) => {
+    const userId = await getAuthUserId(ctx);
+    if (userId === null) throw new Error("Not authenticated");
+    const saved = await ctx.db.query("saves").withIndex("by_user_slug", (q) => q.eq("userId", userId).eq("slug", slug)).unique();
+    if (saved === null) throw new Error("Save not found");
+    if (folderId !== null) {
+      const folder = await ctx.db.get(folderId);
+      if (folder === null || folder.userId !== userId) throw new Error("Not found");
+    }
+    const folders = await ctx.db.query("collections").withIndex("by_user", (q) => q.eq("userId", userId)).collect();
+    for (const folder of folders) {
+      const items = await ctx.db.query("collectionItems").withIndex("by_collection", (q) => q.eq("collectionId", folder._id)).collect();
+      for (const item of items) if (item.slug === slug) await ctx.db.delete(item._id);
+    }
+    if (folderId !== null) {
+      const folder = await ctx.db.get(folderId);
+      if (folder === null) throw new Error("Not found");
+      const items = await ctx.db.query("collectionItems").withIndex("by_collection", (q) => q.eq("collectionId", folderId)).collect();
+      const position = items.reduce((max, item) => Math.max(max, item.position), -1) + 1;
+      await ctx.db.insert("collectionItems", { collectionId: folderId, slug, position });
+    }
+    return null;
+  },
+});
+
 export const add = mutation({
   args: { slug: v.string() },
   returns: v.null(),

--- a/docs/saved-library.md
+++ b/docs/saved-library.md
@@ -1,0 +1,13 @@
+# Saved library
+
+Signed-in users can save components from the catalog with the bookmark icon in the upper-right corner of a preview.
+
+Open **Account → Saved** to browse saved components as live previews. Each saved item includes:
+
+- **Details**, which opens the full component page with its install information.
+- A copy button for the `shadcn` install command.
+- A folder selector for organizing the item.
+
+Use **New folder** to create private folders such as `Navigation`, `Forms`, or `Experiments`. A save can be unfiled or placed in one folder at a time. Folders are private and are not published to profile pages.
+
+Moving a save to **Unfiled** keeps the save and only removes its folder assignment.


### PR DESCRIPTION
## Summary
- replace the narrow saved-name list with live preview cards
- link saved items to full component detail pages with copyable install commands
- move catalog save controls into icon bookmark buttons on previews
- add private saved folders with create, move, rename, and delete backend support
- document saved-library and folder behavior

## Verification
- `npm run typecheck`
- `npm run build`
- production browser smoke check: 265 bookmark controls, detail copy button, signed-out account gate
