### PR TITLE
Open saved components in working preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ agent working inside this repo.
 ## Saved library
 
 Signed-in users can bookmark components from the catalog. The account's Saved
-view shows component details, copyable install commands, and private
+view shows working interactive previews, copyable install commands, and private
 folders for organizing saves. See [`docs/saved-library.md`](docs/saved-library.md).
 
 ## License

--- a/app/_components/saved-library.tsx
+++ b/app/_components/saved-library.tsx
@@ -66,7 +66,7 @@ export function SavedLibrary({ items, slugs, initialFolders }: { items: Item[]; 
             const installCommand = `npx shadcn add ${REGISTRY_ORIGIN}/r/${item.name}.json`;
             return (
               <li key={item.name} className="overflow-hidden rounded-md border border-border bg-surface">
-                <Link href={`/components/${item.name}`} className="group block outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent">
+                <Link href={`/preview/${item.name}/play`} className="group block outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent">
                   <div className="border-b border-border px-4 py-5 transition-colors group-hover:bg-foreground/[0.03]">
                     <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted">Saved component</p>
                     <h3 className="mt-2 text-sm font-semibold tracking-tight text-foreground">{item.title}</h3>
@@ -80,7 +80,7 @@ export function SavedLibrary({ items, slugs, initialFolders }: { items: Item[]; 
                     {folders.map((entry) => <option key={entry.id} value={entry.id}>{entry.name}</option>)}
                   </select>
                   <CopyButton value={installCommand} label={`Copy install command for ${item.title}`} />
-                  <Link href={`/components/${item.name}`} className="rounded-sm px-2 py-1 text-xs text-muted outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent">Details</Link>
+                  <Link href={`/preview/${item.name}/play`} className="rounded-sm px-2 py-1 text-xs text-muted outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-accent">Open preview</Link>
                 </div>
               </li>
             );

--- a/docs/saved-library.md
+++ b/docs/saved-library.md
@@ -4,10 +4,14 @@ Signed-in users can save components from the catalog with the bookmark icon in t
 
 Open **Account → Saved** to browse saved components. Each saved item includes:
 
-- **Details**, which opens the full component page with its install information.
+- **Open preview**, which opens the same working interactive route used by the catalog.
 - A copy button for the `shadcn` install command.
 - A folder selector for organizing the item.
 
 Use **New folder** to create private folders such as `Navigation`, `Forms`, or `Experiments`. A save can be unfiled or placed in one folder at a time. Folders are private and are not published to profile pages.
 
 Moving a save to **Unfiled** keeps the save and only removes its folder assignment.
+
+## Route note
+
+The interactive `/preview/<name>/play` route currently renders some components more accurately than `/components/<name>`. Saved items therefore open the preview route until the canonical component pages reach rendering parity.


### PR DESCRIPTION
Wire saved library cards and actions to the working /preview/<name>/play route. Document the current rendering-parity note for /components/<name>. Verified with npm run typecheck.