### PR TITLE
chore: bump CLI to 0.3.0 and MCP to 0.2.0 for republish

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nikolas.sapa/ns-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI for the ns-ui component registry: search, browse, and install shadcn-compatible components from the terminal.",
   "keywords": [
     "shadcn",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nikolas.sapa/ns-ui-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for the ns-ui component registry: search components, read full source, and get the token/theming conventions an agent needs to build in the same design language.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Both published packages ship stale registry snapshots listing the 223 **pre-rename** slugs. Verified by opening the tarballs:

| package | file | contents |
|---|---|---|
| `@nikolas.sapa/ns-ui@0.2.0` | `data/registry-index.json` | 223 old slugs, zero new |
| `@nikolas.sapa/ns-ui-mcp@0.1.0` | `data/registry-snapshot.json` | 223 old slugs, zero new |

Sampled 12 against the live origin before the redirect fix: **12/12 returned 404**. The MCP one is worse — it hands install URLs to agents rather than to a human who might notice and complain.

The redirect layer already shipped, so this is not an outage fix. It is what demotes that layer from load-bearing to a safety net, and it gets the 38 components added since (228 → 266) into both packages.

No source changes: both `prepack` hooks regenerate their snapshot from the current registry at publish time, so the version bump alone is what ships correct data.

**Publishing still needs an interactive `npm login`** — npm auth currently returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)