### PR TITLE
docs: open-source community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,6 +55,18 @@ body:
         - label: Dark
         - label: Light
 
+  - type: input
+    id: react-version
+    attributes:
+      label: React version
+      placeholder: "19.2.7"
+
+  - type: input
+    id: tailwind-version
+    attributes:
+      label: Tailwind version
+      placeholder: "4.3.2"
+
   - type: textarea
     id: env
     attributes:
@@ -62,4 +74,4 @@ body:
       placeholder: |
         Browser: Chrome 141
         OS: macOS 15.2
-        React / Next versions:
+        Next version:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Propose a change to the CLI, MCP server, registry site, or tooling.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Proposing a new component? Use "Component request" instead — this
+        template is for the CLI, the MCP server, the registry/preview site,
+        or the build tooling.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that isn't possible, or is awkward, today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: As concrete as you can make it — a command, a flag, an API shape.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,7 @@
 - [ ] Colors come from CSS custom properties, not hardcoded hex, including in canvas/SVG draw code
 - [ ] No generated file is in the diff (`registry.json`, `registry/index.tsx`, `public/r/*`, `public/llms*.txt`, `lib/*.generated.json`)
 - [ ] Every commit is signed off (`git commit -s`) per the [DCO](../DCO)
+- [ ] Accessibility basics: reachable and operable by keyboard, a visible focus state, and no motion that ignores `prefers-reduced-motion`
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # ns-ui
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Live registry](https://img.shields.io/badge/registry-design.helpmarq.com-006bff)](https://design.helpmarq.com)
-[![CI](https://github.com/nikolas-sapa/ns-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/nikolas-sapa/ns-ui/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-0B0B0D?style=flat-square&labelColor=0B0B0D&color=0B0B0D)](LICENSE)
+[![React 19](https://img.shields.io/badge/react-19-0B0B0D?style=flat-square&labelColor=0B0B0D&color=0B0B0D)](package.json)
+[![Tailwind v4](https://img.shields.io/badge/tailwind-v4-0B0B0D?style=flat-square&labelColor=0B0B0D&color=0B0B0D)](package.json)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-0B0B0D?style=flat-square&labelColor=0B0B0D&color=0B0B0D)](CONTRIBUTING.md)
+[![Live registry](https://img.shields.io/badge/registry-design.helpmarq.com-0B0B0D?style=flat-square&labelColor=0B0B0D&color=0B0B0D)](https://design.helpmarq.com)
+[![CI](https://github.com/nikolas-sapa/ns-ui/actions/workflows/ci.yml/badge.svg?style=flat-square)](https://github.com/nikolas-sapa/ns-ui/actions/workflows/ci.yml)
 
 <!-- generated:count start -->266<!-- generated:count end --> React components you install by URL, no package to depend on. Every one is
 built around a single interaction and gated by a Playwright suite that refuses


### PR DESCRIPTION
Adds the GitHub community-standards set so the repo reads as a real open-source project rather than a code dump.

- CONTRIBUTING.md with the actual dev setup, build and test commands
- CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
- SECURITY.md with a private disclosure path
- Issue forms (bug, feature) and a PR template
- README: shield badges, quick start, contributing and license sections

Docs only. No source or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NB5BtCLryWRFcxmqK1tydR