### PR TITLE
fix: DCO check rejected merge commits, which cannot be signed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,12 @@ jobs:
         run: |
           set -euo pipefail
           range="${BASE_SHA}..${HEAD_SHA}"
-          commits=$(git log --format=%H "$range")
+          # `--no-merges`: a merge commit has no author asserting anything —
+          # it is a graph operation. GitHub's own "Update branch" button
+          # creates one, and it cannot carry a sign-off, so checking them made
+          # the button unusable and blocked otherwise-signed PRs. The DCO
+          # covers authored work, which is exactly the non-merge commits.
+          commits=$(git log --no-merges --format=%H "$range")
           count=$(echo "$commits" | grep -c . || true)
           if [ "$count" -eq 0 ]; then
             echo "DCO check examined 0 commits (bad range: $range) — failing rather than passing on nothing checked."
@@ -82,4 +87,4 @@ jobs:
           if [ "$fail" -ne 0 ]; then
             exit 1
           fi
-          echo "$count commit(s) checked, all signed off."
+          echo "$count non-merge commit(s) checked, all signed off."


### PR DESCRIPTION
A merge commit has no author asserting anything — it's a graph operation, and nothing generates a `Signed-off-by` for one.

GitHub's own **Update branch** button creates exactly such a commit. Combined with branch protection's strict up-to-date requirement, any PR that fell behind `main` became unmergeable: updating the branch introduced a commit the check would always reject, and the only escape was a force-push.

This blocked three PRs in one session. Now `--no-merges`, which is what the DCO actually covers: authored work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)