### PR TITLE
Organization address (GR) and the spaced brand spelling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -121,6 +121,7 @@ const identityJsonLd = {
       "@type": "SoftwareApplication",
       "@id": `${REGISTRY_ORIGIN}/#software`,
       name: "ns-ui",
+      alternateName: "ns ui",
       url: REGISTRY_ORIGIN,
       description:
         "A registry of React components you install by URL — each built around a single interaction, each installed as plain source with no runtime package.",
@@ -139,12 +140,18 @@ const identityJsonLd = {
       "@type": "Organization",
       "@id": `${REGISTRY_ORIGIN}/#organization`,
       name: "ns-ui",
-      alternateName: "ns-ui component registry",
+      // Both spellings, because people search the spaced one: "ns ui" is what
+      // gets typed, "ns-ui" is what the package and the domain are called.
+      alternateName: ["ns ui", "ns-ui component registry"],
       url: REGISTRY_ORIGIN,
       logo: `${REGISTRY_ORIGIN}/opengraph-image`,
       description:
         "The maintainer of ns-ui, an open-source (MIT) registry of React components for shadcn-compatible tooling.",
       founder: { "@type": "Person", name: "Nikolas Sapalidis" },
+      // Country only. There is no published street address for this project,
+      // and a schema.org PostalAddress does not require one — an invented
+      // street is worse markup than an honest partial address.
+      address: { "@type": "PostalAddress", addressCountry: "GR" },
       sameAs: [
         "https://github.com/nikolas-sapa/ns-ui",
         "https://www.npmjs.com/package/@nikolas.sapa/ns-ui",

--- a/scripts/test-agent-readiness.ts
+++ b/scripts/test-agent-readiness.ts
@@ -256,6 +256,18 @@ async function homepageMetadata() {
     .flatMap((p) => (p?.["@graph"] as Record<string, unknown>[] | undefined) ?? (p ? [p] : []))
     .find((n) => n["@type"] === "Organization");
   check("  Organization has a contactPoint", Array.isArray(org?.contactPoint) && org.contactPoint.length > 0);
+  check(
+    "  Organization has an address with a country",
+    typeof (org?.address as { addressCountry?: string } | undefined)?.addressCountry === "string",
+    JSON.stringify(org?.address),
+  );
+  // The spaced spelling is what people type into a search box; it appears
+  // nowhere in the visible copy, so the markup is the only place it lives.
+  check(
+    "  Organization lists the spaced brand spelling",
+    JSON.stringify(org?.alternateName ?? "").includes("ns ui"),
+    JSON.stringify(org?.alternateName),
+  );
 
   // The H1 has always been server-rendered; what regressed was where. An
   // agent that truncates a fetch has to reach it — the sidebar tree used to


### PR DESCRIPTION
Owner-supplied facts the previous pass left blank: country GR (no street — none is published, and PostalAddress does not require one) and `ns ui` as an alternateName on both the Organization and the SoftwareApplication, since the spaced spelling is what gets typed into a search box and appears nowhere in the visible copy.

53/53 agent-readiness checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDkQ46cdgGauBABmUwXWfR