### PR TITLE
Agent readiness round 2: H1 reachability, /docs + OpenAPI, MCP aliases

### DIFF
--- a/app/_components/site-footer.tsx
+++ b/app/_components/site-footer.tsx
@@ -44,6 +44,10 @@ const COLUMNS: { heading: string; links: FooterLink[] }[] = [
   {
     heading: "For AI agents",
     links: [
+      // Named "Developer docs", not "/docs": this is the row someone scans
+      // for when they are looking for an API, and the path alone did not say
+      // that.
+      { href: "/docs", label: "Developer docs" },
       { href: "/llms.txt", label: "/llms.txt" },
       { href: "/llms-full.txt", label: "/llms-full.txt" },
     ],

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import registry from "@/registry.json";
+import { REGISTRY_ORIGIN } from "@/lib/registry-origin";
+
+// Static by construction — same rule as /about and /guidelines.
+//
+// /connect already explains how to wire the registry into an agent, and it
+// stays the page for that. This one exists for a different reader: something
+// looking up "ns-ui developer docs" or "ns-ui API" by name and expecting a
+// predictable URL to exist. It is a flat index of every machine-readable
+// surface with its literal URL — no prose an agent has to interpret, and
+// nothing here that isn't reachable.
+
+const title = "ns-ui developer docs — API, registry JSON, MCP server, CLI";
+const description =
+  "Every machine-readable ns-ui endpoint at its literal URL: the shadcn registry index, per-component JSON, the OpenAPI spec, the MCP server handshake, llms.txt, and markdown content negotiation.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: "/docs" },
+  openGraph: { title, description },
+};
+
+const LINK =
+  "underline underline-offset-2 transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ns-accent motion-reduce:transition-none";
+
+const H2 = "text-lg font-medium tracking-[-0.02em] text-foreground";
+const P = "mt-2 text-sm leading-6 text-ns-muted";
+const URL_ROW = "font-mono text-xs text-foreground";
+
+type Entry = { url: string; what: string; note?: string };
+
+const REGISTRY_API: Entry[] = [
+  {
+    url: "/registry.json",
+    what: `The shadcn registry index — all ${registry.items.length} items with names, titles, descriptions and tags.`,
+    note: "Also served at /r/registry.json; both are the same file.",
+  },
+  {
+    url: "/r/<name>.json",
+    what: "One component's registry item: dependencies, CSS variables, and the real source in files[].content.",
+    note: "This is what `npx shadcn add` reads.",
+  },
+  {
+    url: "/openapi.json",
+    what: "OpenAPI 3.1 description of every endpoint on this page.",
+  },
+];
+
+const AGENT_SURFACE: Entry[] = [
+  {
+    url: "/.well-known/mcp",
+    what: "MCP server. POST JSON-RPC (Streamable HTTP) for initialize, tools/list and tools/call; GET returns the manifest.",
+    note: "Also answers at /mcp and /.well-known/mcp.json.",
+  },
+  {
+    url: "/llms.txt",
+    what: "Agent quickstart: install command, token contract, and one block per component.",
+  },
+  {
+    url: "/llms-full.txt",
+    what: "The long form — a full paragraph of behavioral detail per component.",
+  },
+  {
+    url: "Accept: text/markdown",
+    what: "Send that header to any page on this site and it answers with a markdown version of itself.",
+    note: "acceptmarkdown.com-compliant, including the Vary header and q-values.",
+  },
+  {
+    url: "/sitemap.xml",
+    what: "Every indexed page, including one per component.",
+  },
+];
+
+const PACKAGES: Entry[] = [
+  {
+    url: "npx -y @nikolas.sapa/ns-ui-mcp",
+    what: "The same MCP server over stdio, for clients that do not speak HTTP transport.",
+  },
+  {
+    url: "npx @nikolas.sapa/ns-ui add <name>",
+    what: "CLI: search, inspect and install components from a terminal.",
+  },
+];
+
+function Section({ heading, entries }: { heading: string; entries: Entry[] }) {
+  return (
+    <section className="mt-10 max-w-2xl">
+      <h2 className={H2}>{heading}</h2>
+      <dl className="mt-4 space-y-5">
+        {entries.map((entry) => (
+          <div key={entry.url}>
+            <dt className={URL_ROW}>{entry.url}</dt>
+            <dd className="mt-1 text-sm leading-6 text-ns-muted">
+              {entry.what}
+              {entry.note ? <span className="block text-ns-muted/80">{entry.note}</span> : null}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+export default function DocsPage() {
+  return (
+    <main className="mx-auto flex max-w-3xl flex-col px-6 py-16 sm:px-10">
+      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-ns-muted">
+        ns-ui / docs
+      </p>
+      <h1 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">
+        ns-ui developer docs.
+      </h1>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-ns-muted">
+        Every endpoint below is public, needs no key and no account, and is
+        relative to{" "}
+        <code className="font-mono text-foreground">{REGISTRY_ORIGIN}</code>. If
+        you want the walkthrough version — per-client MCP config, CLI examples —
+        that is on{" "}
+        <Link href="/connect" className={LINK}>
+          /connect
+        </Link>
+        .
+      </p>
+
+      <div className="mt-8 border-t border-border pt-2">
+        <Section heading="Registry API" entries={REGISTRY_API} />
+        <Section heading="Agent surface" entries={AGENT_SURFACE} />
+        <Section heading="Packages" entries={PACKAGES} />
+      </div>
+
+      <section className="mt-10 max-w-2xl">
+        <h2 className={H2}>Authentication</h2>
+        <p className={P}>
+          There is none. Every endpoint above is public, anonymous and read-only;
+          nothing here accepts a write. Account features (saving components,
+          collections) exist on the site but have no public API — see{" "}
+          <Link href="/privacy" className={LINK}>
+            /privacy
+          </Link>{" "}
+          for what they store.
+        </p>
+      </section>
+
+      <section className="mt-10 max-w-2xl">
+        <h2 className={H2}>Licensing</h2>
+        <p className={P}>
+          MIT, components included. Install them, edit them, ship them — the
+          source lands in your repository and there is no runtime package to
+          depend on. More about the project on{" "}
+          <Link href="/about" className={LINK}>
+            /about
+          </Link>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/openapi.json/route.ts
+++ b/app/openapi.json/route.ts
@@ -1,0 +1,175 @@
+import registry from "@/registry.json";
+import pkg from "@/package.json";
+import { REGISTRY_ORIGIN } from "@/lib/registry-origin";
+
+// OpenAPI 3.1 description of the public, anonymous, read-only surface —
+// exactly the endpoints /docs lists, at the URL a tool looking for a spec
+// tries first.
+//
+// Hand-written rather than generated: this API is four endpoints that change
+// on the scale of years, and a generator would need a decorator layer on
+// route handlers that otherwise have none. What DOES change — the component
+// count, the origin — is interpolated from the same sources the rest of the
+// app reads, so the spec cannot drift into claiming a stale number.
+//
+// Account routes under /api are deliberately absent. They exist, but they are
+// session-cookie internals for this site's own UI, not a public API, and
+// documenting them here would invite exactly the integration they do not
+// support.
+export const runtime = "nodejs";
+
+const spec = {
+  openapi: "3.1.0",
+  info: {
+    title: "ns-ui registry API",
+    version: pkg.version,
+    summary: `Public read-only API for the ns-ui component registry (${registry.items.length} React components).`,
+    description:
+      "Every endpoint is public, anonymous and read-only — no key, no account, no rate limit worth documenting. " +
+      "The registry follows the shadcn registry schema, so `npx shadcn add <item url>` works directly against it.",
+    license: { name: "MIT", identifier: "MIT" },
+    contact: { name: "ns-ui", url: `${REGISTRY_ORIGIN}/about` },
+  },
+  servers: [{ url: REGISTRY_ORIGIN }],
+  externalDocs: { description: "Developer docs", url: `${REGISTRY_ORIGIN}/docs` },
+  paths: {
+    "/registry.json": {
+      get: {
+        operationId: "getRegistryIndex",
+        summary: "The registry index",
+        description:
+          "Every item in the registry with its name, title, description and tags. Conforms to https://ui.shadcn.com/schema/registry.json. Also served at /r/registry.json.",
+        responses: {
+          "200": {
+            description: "The registry index",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    $schema: { type: "string" },
+                    name: { type: "string" },
+                    homepage: { type: "string", format: "uri" },
+                    items: { type: "array", items: { $ref: "#/components/schemas/RegistryItem" } },
+                  },
+                  required: ["name", "items"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/r/{name}.json": {
+      get: {
+        operationId: "getComponent",
+        summary: "One component's registry item, including its real source",
+        description:
+          "What `npx shadcn add` reads: dependencies, CSS variables, and the component source in files[].content. Conforms to https://ui.shadcn.com/schema/registry-item.json.",
+        parameters: [
+          {
+            name: "name",
+            in: "path",
+            required: true,
+            description: "Component name, e.g. `undo-ghost-row`.",
+            schema: { type: "string" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "The registry item",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/RegistryItem" } },
+            },
+          },
+          "404": { description: "No component with that name" },
+        },
+      },
+    },
+    "/.well-known/mcp": {
+      get: {
+        operationId: "getMcpManifest",
+        summary: "MCP server manifest",
+        description:
+          "Transport, protocol version and tool list. Answers 405 to a request whose Accept asks for text/event-stream: this server is stateless and offers no server-to-client stream. Also reachable at /mcp and /.well-known/mcp.json.",
+        responses: {
+          "200": { description: "Manifest", content: { "application/json": {} } },
+          "405": { description: "No server-to-client stream is offered" },
+        },
+      },
+      post: {
+        operationId: "callMcp",
+        summary: "MCP over Streamable HTTP (JSON-RPC 2.0)",
+        description:
+          "Supports initialize, ping, tools/list and tools/call. Notifications (no id) return 202 with no body. Tools: search_components, get_component, install_command.",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  jsonrpc: { type: "string", const: "2.0" },
+                  id: { type: ["string", "number", "null"] },
+                  method: { type: "string" },
+                  params: { type: "object" },
+                },
+                required: ["jsonrpc", "method"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "JSON-RPC response", content: { "application/json": {} } },
+          "202": { description: "Notification accepted; no response body" },
+          "400": { description: "Body was not valid JSON" },
+        },
+      },
+    },
+    "/llms.txt": {
+      get: {
+        operationId: "getLlmsTxt",
+        summary: "Agent quickstart",
+        description:
+          "Install command, the CSS token contract components require, and one block per component. /llms-full.txt is the same catalog with a full paragraph of behavioral detail each.",
+        responses: {
+          "200": { description: "Plain text", content: { "text/plain": {} } },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      RegistryItem: {
+        type: "object",
+        description: "A shadcn registry item. See https://ui.shadcn.com/schema/registry-item.json.",
+        properties: {
+          name: { type: "string" },
+          type: { type: "string", examples: ["registry:ui"] },
+          title: { type: "string" },
+          description: { type: "string" },
+          dependencies: { type: "array", items: { type: "string" } },
+          files: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+                content: { type: "string", description: "The component's real source." },
+                type: { type: "string" },
+                target: { type: "string" },
+              },
+            },
+          },
+        },
+        required: ["name", "type"],
+      },
+    },
+  },
+};
+
+export function GET(): Response {
+  return Response.json(spec, {
+    headers: { "cache-control": "public, max-age=0, must-revalidate" },
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -189,6 +189,16 @@ export default async function Home() {
   const stars = await getStarCount();
   return (
     <>
+      <Showcase items={items} featured={featured} stars={stars} />
+      {/* Structured data LAST, not first. Position is irrelevant to
+          schema.org — a parser reads the whole document — but it is not
+          irrelevant to a crawler that truncates: `collectionPageJsonLd`
+          serializes ~55KB of ItemList for the full catalog, and while it sat
+          ahead of the markup it pushed the page's <h1> to byte 63,882, past
+          where agents that cut a fetch short stop reading. That offset is the
+          entire reason an agent audit reported "no H1" on a page that has
+          always server-rendered one. Moving these two blocks below the
+          content puts the heading at ~8KB and changes nothing else. */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: jsonLdScript(identityJsonLd) }}
@@ -197,7 +207,6 @@ export default async function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: jsonLdScript(collectionPageJsonLd) }}
       />
-      <Showcase items={items} featured={featured} stars={stars} />
     </>
   );
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -65,6 +65,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
     // excluded above: a page nothing links to from the sitemap is a page an
     // agent verifying this project's legitimacy has to guess the URL of.
     {
+      url: `${REGISTRY_ORIGIN}/docs`,
+      lastModified: new Date(),
+    },
+    {
       url: `${REGISTRY_ORIGIN}/about`,
       lastModified: new Date(),
     },

--- a/lib/markdown-negotiation.ts
+++ b/lib/markdown-negotiation.ts
@@ -29,31 +29,24 @@ function parseAccept(header: string): Ranked[] {
     .filter((r) => r.type.length > 0);
 }
 
-// Highest q for `type`, honouring the "*/*" and "text/*" wildcard ranges.
-function qFor(ranked: Ranked[], type: string): number {
-  const [group] = type.split("/");
-  let best = 0;
-  for (const r of ranked) {
-    if (r.type === type || r.type === `${group}/*` || r.type === "*/*") {
-      best = Math.max(best, r.q);
-    }
-  }
-  return best;
-}
-
 /**
- * True only when the client named `text/markdown` explicitly AND ranked it at
- * least as high as `text/html`.
+ * True only when the client named `text/markdown` explicitly AND ranked it
+ * STRICTLY above whatever else it will accept.
  *
- * Explicitly, not "no text/html found": a bare `curl` sends the catch-all
- * wildcard range, and
- * every unknown crawler that omits the header entirely resolves to the same
- * wildcard. Serving those markdown would change what the site returns to most
- * non-browser traffic, which is a far bigger blast radius than the one this
- * feature is for.
+ * Explicitly, because a bare `curl` and every crawler that omits the header
+ * resolve to the catch-all range, and serving those markdown would change
+ * what most non-browser traffic gets.
  *
- * Ties go to markdown: a client that bothered to list `text/markdown` at equal
- * weight is asking for it.
+ * Strictly, because of what ties mean in practice. `Accept: text/markdown`
+ * on its own is a client that wants markdown and nothing else — the exact
+ * request acceptmarkdown.com's conformance check sends, and it still gets
+ * markdown here. A markdown listing alongside the catch-all range is a
+ * different animal: an
+ * indexer saying "markdown is fine, so is anything else", and handing that
+ * one markdown swaps the page's real HTML — headings, structured data, the
+ * whole document — for a text file, which is how an agent audit came to
+ * report "no H1" on this site. Equal weight is not a preference, so the
+ * catch-all wins and HTML is served.
  */
 export function prefersMarkdown(accept: string | null): boolean {
   if (!accept) return false;
@@ -62,5 +55,12 @@ export function prefersMarkdown(accept: string | null): boolean {
     (r) => r.type === "text/markdown" || r.type === "text/x-markdown",
   );
   if (!markdown || markdown.q === 0) return false;
-  return markdown.q >= qFor(ranked, "text/html");
+
+  // Everything the client would also take: HTML by name, plus either wildcard
+  // range. The markdown entry itself is excluded so it never outranks itself.
+  const alternatives = ranked.filter(
+    (r) => r !== markdown && (r.type === "text/html" || r.type === "text/*" || r.type === "*/*"),
+  );
+  if (alternatives.length === 0) return true;
+  return markdown.q > Math.max(...alternatives.map((r) => r.q));
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -46,12 +46,21 @@ const nextConfig: NextConfig = {
         // exist for. Prose routes never contain a dot; every static file does,
         // so excluding dotted paths is the whole rule.
         {
-          source: "/:path((?!api/|_next/|r/|\\.well-known/)[^.]*)",
+          source: "/:path((?!api/|_next/|r/|mcp|\\.well-known/)[^.]*)",
           has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
           destination: "/api/md/:path",
         },
       ],
-      afterFiles: [{ source: "/registry.json", destination: "/r/registry.json" }],
+      afterFiles: [
+        { source: "/registry.json", destination: "/r/registry.json" },
+        // Two aliases onto the one MCP handler, because clients disagree about
+        // where a server lives: `/mcp` is what most config snippets use, and
+        // `.json` is what a crawler expecting a static manifest tries. Same
+        // route, so GET and POST behave identically at all three URLs and
+        // there is no second copy of the handshake to drift.
+        { source: "/mcp", destination: "/.well-known/mcp" },
+        { source: "/.well-known/mcp.json", destination: "/.well-known/mcp" },
+      ],
     };
   },
   // The HTML half of the same negotiation, best-effort.

--- a/scripts/build-llms.ts
+++ b/scripts/build-llms.ts
@@ -612,8 +612,11 @@ is the whole dependency.
 - ${CLI_LINE}
 
 Developer resources, by URL (every one of these is live — no key, no account):
+- Developer docs index (every endpoint below, with its shape): ${HOMEPAGE}/docs
+- OpenAPI 3.1 spec for this API: ${HOMEPAGE}/openapi.json
 - MCP over HTTP, no install: POST JSON-RPC to ${HOMEPAGE}/.well-known/mcp
   (GET the same URL for the manifest: transport, protocol version, tool list).
+  The same handler answers at ${HOMEPAGE}/mcp and ${HOMEPAGE}/.well-known/mcp.json.
 - Registry index (shadcn schema, every component): ${HOMEPAGE}/registry.json
 - One component's install spec and real source: ${HOMEPAGE}/r/<name>.json
 - Human-readable page per component: ${HOMEPAGE}/components/<name>

--- a/scripts/test-agent-readiness.ts
+++ b/scripts/test-agent-readiness.ts
@@ -77,6 +77,27 @@ async function markdownNegotiation() {
     `got "${html.headers.get("content-type")}"`,
   );
 
+  // The tie rule. An indexer saying "markdown is fine, so is anything else"
+  // must get the real page — serving it markdown replaces the document (and
+  // its <h1>) with a text file, which is what an audit read as a missing
+  // heading.
+  const wildcard = await fetch(url("/"), { headers: { accept: "text/markdown, */*" } });
+  check(
+    "markdown tied with a wildcard still gets HTML",
+    (wildcard.headers.get("content-type") ?? "").includes("text/html"),
+    `got "${wildcard.headers.get("content-type")}"`,
+  );
+
+  // ...but naming markdown above the wildcard is a real preference.
+  const explicit = await fetch(url("/"), {
+    headers: { accept: "text/markdown, */*;q=0.5" },
+  });
+  check(
+    "markdown ranked above a wildcard gets markdown",
+    (explicit.headers.get("content-type") ?? "").includes("text/markdown"),
+    `got "${explicit.headers.get("content-type")}"`,
+  );
+
   // A browser (or a bare `curl`, which sends the wildcard) must be untouched.
   const plain = await fetch(url("/"), { headers: { accept: "*/*" } });
   check(
@@ -212,6 +233,18 @@ async function mcpEndpoint() {
   const text = callBody.result?.content?.[0]?.text ?? "";
   check("tools/call returns results", text.includes('"results"'), text.slice(0, 60));
 
+  // Clients disagree about where an MCP server lives; all three URLs are the
+  // same handler, so all three must hand-shake.
+  for (const alias of ["/mcp", "/.well-known/mcp.json"]) {
+    const aliased = await fetch(url(alias), {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 9, method: "tools/list" }),
+    });
+    const body = (await safeJson<{ result?: { tools?: unknown[] } }>(aliased)) ?? {};
+    check(`${alias} answers the same handshake`, (body.result?.tools?.length ?? 0) > 0, `got ${aliased.status}`);
+  }
+
   const unknown = await rpc({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "nope" } });
   const unknownBody = (await safeJson<{ error?: { code?: number } }>(unknown)) ?? {};
   check("unknown tool is a JSON-RPC error", unknownBody.error?.code === -32602, JSON.stringify(unknownBody.error));
@@ -274,11 +307,47 @@ async function homepageMetadata() {
   // put it ~290KB in.
   const h1 = html.indexOf("<h1");
   check("homepage has an H1 in raw HTML", h1 !== -1);
-  check("  H1 is within the first 100KB", h1 !== -1 && h1 < 100_000, `at byte ${h1}`);
+  // 20KB, not 100: the catalog's ItemList JSON-LD is ~55KB on its own, and
+  // while it sat above the markup the heading was at byte 63,882. Anything
+  // that large creeping back in front of the content fails here.
+  check("  H1 is within the first 20KB", h1 !== -1 && h1 < 20_000, `at byte ${h1}`);
 
   for (const tag of ['property="og:image"', 'property="og:type"', 'lang="en"']) {
     check(`homepage has ${tag}`, html.includes(tag));
   }
+}
+
+async function developerResources() {
+  console.log("\nDeveloper resource discoverability");
+
+  const docs = await fetch(url("/docs"));
+  const html = await docs.text();
+  check("/docs responds 200", docs.status === 200, `got ${docs.status}`);
+  // The audit's complaint was name-based: a search for the product's docs
+  // found nothing. The product name has to be IN the title and the heading,
+  // not just implied by the domain.
+  const title = html.match(/<title>([^<]*)<\/title>/)?.[1] ?? "";
+  check("  /docs names the product in its <title>", /ns-ui/i.test(title), title);
+  const h1 = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/)?.[1]?.replace(/<[^>]+>/g, "") ?? "";
+  check("  /docs names the product in its H1", /ns-ui/i.test(h1), h1.trim());
+  for (const path of ["/openapi.json", "/.well-known/mcp", "/llms.txt", "/registry.json"]) {
+    check(`  /docs links ${path}`, html.includes(path));
+  }
+
+  const spec = await fetch(url("/openapi.json"));
+  const doc = (await safeJson<Record<string, unknown>>(spec)) ?? {};
+  check("/openapi.json responds 200", spec.status === 200, `got ${spec.status}`);
+  check("  is an OpenAPI 3.1 document", String(doc.openapi ?? "").startsWith("3.1"), String(doc.openapi));
+  const paths = Object.keys((doc.paths as Record<string, unknown>) ?? {});
+  check("  documents the registry index", paths.includes("/registry.json"), paths.join(", "));
+  check("  documents the MCP endpoint", paths.includes("/.well-known/mcp"), paths.join(", "));
+
+  const llms = await (await fetch(url("/llms.txt"))).text();
+  check("llms.txt names the docs index", llms.includes("/docs"));
+  check("llms.txt names the OpenAPI spec", llms.includes("/openapi.json"));
+
+  const sitemap = await (await fetch(url("/sitemap.xml"))).text();
+  check("sitemap lists /docs", sitemap.includes("/docs"));
 }
 
 async function trustAnchors() {
@@ -316,6 +385,7 @@ await markdownNegotiation();
 await agentFriendly404();
 await mcpEndpoint();
 await homepageMetadata();
+await developerResources();
 await trustAnchors();
 
 console.log(`\n${checks - failures}/${checks} checks passed`);


### PR DESCRIPTION
Second audit pass (69 → 92). Four remaining items.

- **H1 at byte 63,882 → 11,924.** The catalog's ~55KB ItemList JSON-LD rendered *before* the markup. Moved both structured-data blocks below the content; schema.org does not care about position, truncating crawlers do.
- **Markdown negotiation now requires a strict preference.** `Accept: text/markdown, */*` (what LLM crawlers send) was winning ties and replacing the whole HTML document — headings and structured data included — with a text file. Bare `Accept: text/markdown`, the acceptmarkdown.com conformance request, still gets markdown.
- **/docs and /openapi.json**, both naming the product in the title and heading, listed in llms.txt, the sitemap and the footer.
- **MCP now answers at /mcp and /.well-known/mcp.json** as well, via rewrites onto the one handler.

71/71 agent-readiness checks pass; 15 of the new ones were verified red against production first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDkQ46cdgGauBABmUwXWfR