### PR TITLE
chore(release): cli 0.8.0, mcp 0.7.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nikolas.sapa/ns-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CLI for the ns-ui component registry: search, browse, and install shadcn-compatible components from the terminal.",
   "keywords": [
     "shadcn",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nikolas.sapa/ns-ui-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "MCP server for the ns-ui component registry: search components, read full source, and get the token/theming conventions an agent needs to build in the same design language.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Brings the repo in line with npm after publishing round 8a.

- `@nikolas.sapa/ns-ui` 0.7.0 → 0.8.0
- `@nikolas.sapa/ns-ui-mcp` 0.6.0 → 0.7.0

Both are already live on npm (published 2026-08-25). The shipped snapshots carry 424 components across 12 categories, including round 8a's 35 additions and excluding the four cut on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpXYdNoKcss9Cnun8dccqo