### PR TITLE
chore(release): cli 0.8.1, mcp 0.7.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nikolas.sapa/ns-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "CLI for the ns-ui component registry: search, browse, and install shadcn-compatible components from the terminal.",
   "keywords": [
     "shadcn",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nikolas.sapa/ns-ui-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server for the ns-ui component registry: search components, read full source, and get the token/theming conventions an agent needs to build in the same design language.",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Patch release carrying the round-8a card rendering fixes (PR #44) and dropping `surface-crt-glass`, cut on review.

- `@nikolas.sapa/ns-ui` 0.8.0 → 0.8.1
- `@nikolas.sapa/ns-ui-mcp` 0.7.0 → 0.7.1

Both already live on npm. Shipped snapshots carry 423 components across 12 categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpXYdNoKcss9Cnun8dccqo