### PR TITLE
Add /feedback and /suggest pages (+ round playbook doc)

### DIFF
--- a/app/_components/site-footer.tsx
+++ b/app/_components/site-footer.tsx
@@ -63,6 +63,8 @@ const COLUMNS: { heading: string; links: FooterLink[] }[] = [
       // what is stored. Filed here rather than in a fifth column: the grid is
       // sm:grid-cols-4 and a fifth would rewrap it.
       { href: "/about", label: "About" },
+      { href: "/feedback", label: "Feedback" },
+      { href: "/suggest", label: "Suggest a feature" },
       { href: "/privacy", label: "Privacy" },
       { href: "https://github.com/nikolas-sapa/ns-ui", label: "GitHub", external: true },
       {

--- a/app/feedback/page.tsx
+++ b/app/feedback/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+// Static by construction — same rule as /about: no `cookies()`, `headers()`,
+// `searchParams` or Convex read, so this prerenders once and is served from
+// the CDN.
+//
+// ponytail: no form and no table behind it. Every route below is a GitHub
+// issue template that already exists (.github/ISSUE_TEMPLATE/*.yml), so
+// feedback lands where it gets triaged instead of in a second inbox nobody
+// reads. Add a first-party form when GitHub sign-in is demonstrably the
+// thing stopping people from writing in.
+
+const title = "Feedback";
+const description =
+  "Report a bug, flag something wrong on the site, or say what is not working — where each kind of feedback goes.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: "/feedback" },
+  openGraph: { title, description },
+};
+
+const CONTACT_EMAIL = "nikolas.sapalidis@gmail.com";
+const ISSUES = "https://github.com/nikolas-sapa/ns-ui/issues";
+
+const LINK =
+  "underline underline-offset-2 transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ns-accent motion-reduce:transition-none";
+
+const SECTION = "mt-10 max-w-2xl";
+const H2 = "text-lg font-medium tracking-[-0.02em] text-foreground";
+const P = "mt-2 text-sm leading-6 text-ns-muted";
+
+export default function FeedbackPage() {
+  return (
+    <main className="mx-auto flex max-w-3xl flex-col px-6 py-16 sm:px-10">
+      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-ns-muted">
+        Feedback
+      </p>
+      <h1 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">
+        Tell me what is broken.
+      </h1>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-ns-muted">
+        There is no form here on purpose. Everything below goes to the issue
+        tracker the components are actually fixed in, so you can watch the fix
+        land instead of wondering whether the message arrived.
+      </p>
+
+      <section className={`${SECTION} border-t border-border pt-8`}>
+        <h2 className={H2}>A component renders wrong or throws</h2>
+        <p className={P}>
+          Open a{" "}
+          <a
+            href={`${ISSUES}/new?template=bug_report.yml`}
+            className={LINK}
+            target="_blank"
+            rel="noreferrer"
+          >
+            bug report
+          </a>
+          . Include the registry name as used in the install command, the
+          browser, and whether it happens in light, dark, or both — the
+          screenshot gate compares those separately, so which one it is
+          narrows the cause immediately.
+        </p>
+      </section>
+
+      <section className={SECTION}>
+        <h2 className={H2}>Something on this site is wrong</h2>
+        <p className={P}>
+          Broken link, wrong install command, a docs page that contradicts the
+          code: same{" "}
+          <a
+            href={`${ISSUES}/new?template=bug_report.yml`}
+            className={LINK}
+            target="_blank"
+            rel="noreferrer"
+          >
+            bug report
+          </a>
+          , with the URL instead of a component name.
+        </p>
+      </section>
+
+      <section className={SECTION}>
+        <h2 className={H2}>An idea rather than a defect</h2>
+        <p className={P}>
+          Feature ideas and component ideas have their own page —{" "}
+          <Link href="/suggest" className={LINK}>
+            /suggest
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section className={SECTION}>
+        <h2 className={H2}>Anything you would rather not post publicly</h2>
+        <p className={P}>
+          Email{" "}
+          <a href={`mailto:${CONTACT_EMAIL}`} className={LINK}>
+            {CONTACT_EMAIL}
+          </a>
+          . Security reports go privately through GitHub&apos;s{" "}
+          <a
+            href="https://github.com/nikolas-sapa/ns-ui/security/advisories/new"
+            className={LINK}
+            target="_blank"
+            rel="noreferrer"
+          >
+            security advisories
+          </a>{" "}
+          or the same address — never a public issue. What the site stores
+          about you is on{" "}
+          <Link href="/privacy" className={LINK}>
+            /privacy
+          </Link>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -76,6 +76,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${REGISTRY_ORIGIN}/privacy`,
       lastModified: new Date(),
     },
+    {
+      url: `${REGISTRY_ORIGIN}/feedback`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${REGISTRY_ORIGIN}/suggest`,
+      lastModified: new Date(),
+    },
     ...categoryPages().map((c) => ({
       url: `${REGISTRY_ORIGIN}/categories/${c.id}`,
       lastModified: new Date(),

--- a/app/suggest/page.tsx
+++ b/app/suggest/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+// Static by construction — same rule as /about and /feedback.
+//
+// ponytail: routes to the two issue templates that already exist rather than
+// adding a suggestions table. The split it enforces is the editorial one
+// from /guidelines: a component idea is judged on whether it is a single
+// distinct interaction, a feature idea is judged on the CLI/MCP/site, and
+// they are reviewed by different criteria — so they are not one inbox.
+
+const title = "Suggest a feature";
+const description =
+  "Propose a feature for the CLI, MCP server, or site — or a component idea — and what each proposal is judged on.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: "/suggest" },
+  openGraph: { title, description },
+};
+
+const ISSUES = "https://github.com/nikolas-sapa/ns-ui/issues";
+
+const LINK =
+  "underline underline-offset-2 transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ns-accent motion-reduce:transition-none";
+
+const SECTION = "mt-10 max-w-2xl";
+const H2 = "text-lg font-medium tracking-[-0.02em] text-foreground";
+const P = "mt-2 text-sm leading-6 text-ns-muted";
+
+export default function SuggestPage() {
+  return (
+    <main className="mx-auto flex max-w-3xl flex-col px-6 py-16 sm:px-10">
+      <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-ns-muted">
+        Suggest
+      </p>
+      <h1 className="mt-4 text-3xl font-semibold tracking-[-0.035em] sm:text-4xl">
+        Ask for the thing that is missing.
+      </h1>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-ns-muted">
+        Ideas are public, so other people can add to yours instead of opening a
+        second copy of it. Which of the two below you pick decides what the
+        idea is judged on.
+      </p>
+
+      <section className={`${SECTION} border-t border-border pt-8`}>
+        <h2 className={H2}>A component that should exist</h2>
+        <p className={P}>
+          Open a{" "}
+          <a
+            href={`${ISSUES}/new?template=component_request.yml`}
+            className={LINK}
+            target="_blank"
+            rel="noreferrer"
+          >
+            component request
+          </a>
+          . Describe the interaction, not the styling: a button styled
+          differently from an existing button is not a new component here, and
+          two ideas demonstrating the same behavior mean only the clearer one
+          ships. The full standard is on{" "}
+          <Link href="/guidelines" className={LINK}>
+            the guidelines page
+          </Link>
+          .
+        </p>
+        <p className={P}>
+          Already built it? Skip the request and open the pull request through{" "}
+          <Link href="/submit" className={LINK}>
+            /submit
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section className={SECTION}>
+        <h2 className={H2}>A feature in the tooling</h2>
+        <p className={P}>
+          The CLI, the MCP server, this site, or the build tooling: open a{" "}
+          <a
+            href={`${ISSUES}/new?template=feature_request.yml`}
+            className={LINK}
+            target="_blank"
+            rel="noreferrer"
+          >
+            feature request
+          </a>
+          . Say what you were trying to do and where the current surface stopped
+          you — that is the part that cannot be guessed later.
+        </p>
+      </section>
+
+      <section className={SECTION}>
+        <h2 className={H2}>Before you open one</h2>
+        <p className={P}>
+          Search the{" "}
+          <a href={ISSUES} className={LINK} target="_blank" rel="noreferrer">
+            open issues
+          </a>{" "}
+          first, and add to the existing thread if the idea is already there. A
+          reaction on someone else&apos;s issue is a real signal; a duplicate is
+          not. Something broken rather than missing goes to{" "}
+          <Link href="/feedback" className={LINK}>
+            /feedback
+          </Link>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/docs/round-playbook.md
+++ b/docs/round-playbook.md
@@ -1,0 +1,158 @@
+# The round playbook
+
+How to run a full component round with parallel agent teams — sourcing,
+briefing, building, and verifying — distilled from round 8a, which produced
+a working set of new components using this process end to end. Read
+`docs/showpiece-recipe.md` for what makes a single showpiece pass owner
+review, and `docs/review-workflow.md` for the review/verify routes and gate
+mechanics; this document is the layer above both — how to run the round
+that produces the components those two docs judge.
+
+## 1. Sourcing — two axes, one anti-pattern
+
+Everything worth building in round 8a came from two axes:
+
+- **Rendering TECHNIQUE, not subject.** The registry's ~62 ASCII slugs all
+  share one pattern (simulate a scalar field, map luminance through a ramp
+  glyph, keep 85-97% of cells empty) — "which field to simulate" is
+  exhausted. The open axis is the technique itself: sub-cell grids,
+  dithering algorithm families, display-hardware artifacts, print
+  reproduction.
+- **Real physical/industrial/print PROCESS.** Same pull as `weld-pool`,
+  `dye-whorl`, `flyback-tear` in the showpiece recipe — a mechanic borrowed
+  from something that actually exists, not invented cold.
+
+**Documented anti-pattern: web search for trend surfaces.** Searching
+"award site preloader 2026" or "kinetic typography trends" returns Framer
+marketplace listings, Envato templates, and SEO blog posts — not real
+mechanics. This is the traceable failure mode that got two components built
+and then removed from this repo. Don't source from trend search.
+
+**Scouts filter concepts BEFORE proposing them**, against:
+
+- Monochrome-native only — a concept whose identity IS its hue dies. Steel
+  tempering colours was dropped for this.
+- No settings/admin/config surfaces — auto-reject per
+  `docs/showpiece-recipe.md` Filter 1. This killed a railway-interlocking
+  concept whose mechanic was otherwise excellent.
+- No API rate-limiting/quota/credits territory — owner preference.
+- An unforced, unbounded resting loop. A process that finishes and stops
+  fails Filter 2 (alive at rest) in the showpiece recipe.
+
+## 2. The spec-then-build split
+
+Research agents source and rank concepts, then write build-ready specs with
+real numbers — rates, counts, thresholds, freeze frames — before any
+builder starts. Builders get one component each and never share files.
+
+**Research agents have no write tool in this setup.** A full report can
+come back with nowhere to save it. A write-capable agent (the orchestrator,
+or a dedicated scribe agent) must persist specs on the researcher's behalf
+— don't assume the research agent can write its own output to disk.
+
+## 3. The builder brief
+
+Every builder prompt should carry the accumulated bug list below — the
+failure rate dropped as the round went on specifically because later
+builders got more of this list up front. Each item was earned by a real
+bug this round:
+
+- **Zero colour literals, including fallbacks.** Tokens read via
+  `getComputedStyle` + a `MutationObserver`, and **no paint before the
+  first read** — trace the rAF start, `ResizeObserver`, and
+  `IntersectionObserver` resume paths specifically. Two agents this round
+  assumed no early-paint path existed and were wrong.
+- **`--border` is a separator token**, ~1.1:1 contrast in light theme —
+  invisible if used as a fill or stroke colour.
+- **`--ns-accent` is interaction chrome only** (buttons, focus rings).
+  Do not reach for it on a component's one climactic moment — see the
+  showpiece recipe's "accent-tinted pointer highlights" standing check for
+  why this is the single most repeated defect on the project.
+- **Alive at rest** means visibly different at t0/2.5s/5s with no input.
+- **`prefers-reduced-motion` freezes on a deliberately chosen NON-t0**
+  most-structured frame.
+- **Derive geometry from the container's smaller dimension** so it reads at
+  card scale, not just full-bleed.
+- **A canvas needs `w-full h-full`** or JS-set style dimensions, or it
+  falls back to its intrinsic size.
+
+## 4. Tell builders to kill their own work
+
+Several briefs this round said: if, after reading the nearest existing
+component, you conclude yours is a restyle, say so and stop. This worked —
+concepts died for good reasons instead of shipping and being pulled later.
+Two hero concepts were cut at spec stage on exactly this instruction.
+
+## 5. The orchestrator holds the commit boundary
+
+Builders were forbidden `git` and `npm run registry:build` this round, per
+`~/.claude/rules/agents.md`'s "commit boundary stays with the orchestrator."
+
+**Consequence to plan for:** forbidding `registry:build` meant new
+components were never in the generated registry mid-round, which forced a
+throwaway review page (`app/r8a/page.tsx`) that later had to be deleted —
+see `docs/review-workflow.md`'s "Don't do this" section, which now records
+that page as a one-off, not a pattern. Better: let the orchestrator run
+`registry:build` once after each wave, so `/preview/<name>` and `/review`
+work for free instead of hand-rolling a demo page.
+
+## 6. Verify in the real context, never a harness
+
+The most important lesson of the round. An agent "fixed" a centring bug by
+verifying against a standalone Playwright harness that re-implemented the
+draw call, reported the assembly at "0px offset," and missed that the real
+component was drawing past the bottom-right corner of its card.
+
+Every fix must be reproduced and verified in the actual route
+(`/preview/<slug>/embed`), at `deviceScaleFactor` 1 AND 2, in both themes.
+Wait ~5s after `networkidle` — the demo chunk needs more than 1.6s to
+hydrate, or you screenshot a blank frame and misdiagnose.
+
+## 7. What the gates cannot see, and how each was caught anyway
+
+- `scripts/verify.ts` screenshots at dsf 1, so a canvas intrinsic-size bug
+  was invisible — correct at dpr 1, broken at dpr 2. Found by the owner on
+  a Retina display.
+- `verify.ts` navigates `/preview/<name>` without the autoplay parameter
+  (by design — see `docs/review-workflow.md`'s "three routes"), so it can
+  never see an autoplay-latched card. Three curtains recorded their
+  revealed-empty state; found by a runtime audit, not the gate.
+- A component can pass every gate and still be visually dead — one
+  component was pixel-identical for 70s despite a green gate.
+
+**Prescribe the runtime audit as a standing step for every round:** render
+every component's real card at both scale factors, hash the framed element
+over 40+ seconds, and compare the canvas box against its parent.
+
+## 8. Static checks are proxies — verify the property, not the pattern
+
+A grep for canvases with `absolute inset-0` and no `w-full h-full` produced
+seven suspects; all seven were false positives (`position: static` with
+inline sizing). The auditor then ran the actual property at runtime — every
+canvas's bounding box against its parent's — which can't be fooled by a
+sizing mechanism nobody thought of. Zero real overflows.
+
+**Rule: when a static grep flags a defect class, confirm it with a runtime
+measurement of the actual property before acting on it.**
+
+## 9. The owner is the last gate
+
+Feedback comes through `/review` verdicts and notes persisted to
+`.review-state.json` (see `docs/review-workflow.md`). Five components were
+cut this round after passing every automated check. Judged rows are hidden
+by default on `/review` — an empty review page means the round is
+approved, not broken.
+
+## Known traps
+
+- Don't verify against `npm run dev` — Turbopack serves corrupted chunks
+  under parallel load (measured 15-50% false failures vs. 0/12 against a
+  production build).
+- A server started with `&` in one shell call dies when that call returns.
+  Start and verify in a single invocation, or use pm2.
+- `npx tsx scripts/verify.ts` fails with `__name is not defined` — use
+  `npm run verify`.
+- A production `next start` will not see new routes or components without
+  a rebuild and a pm2 restart.
+- A high pm2 restart count is cumulative, not a crash-loop signal — check
+  `unstable restarts`, not just the raw count, before believing it.

--- a/lib/markdown-pages.ts
+++ b/lib/markdown-pages.ts
@@ -86,6 +86,16 @@ const STATIC_PAGES: Record<string, { title: string; summary: string }> = {
     title: "Submit a component",
     summary: "Propose a component for the registry.",
   },
+  "/feedback": {
+    title: "Feedback",
+    summary:
+      "Where to report a bug in a component or on the site, and how to reach the maintainer privately.",
+  },
+  "/suggest": {
+    title: "Suggest a feature",
+    summary:
+      "Where to propose a component idea or a feature for the CLI, MCP server, or site, and what each is judged on.",
+  },
 };
 
 /** Routes that exist but are not prose — asking for markdown here is a 406. */


### PR DESCRIPTION
Two static prose pages routing to the existing GitHub issue templates (bug_report, component_request, feature_request) rather than a new form + Convex table. Registered in the sitemap, the `text/markdown` mirror, and the footer's Community column.

Also carries the pre-existing `docs/round-playbook.md` commit already on this branch.

Verified: `tsc --noEmit` clean, `next build` green, both routes prerendered static (`○ /feedback`, `○ /suggest`) and present in `sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196pYaGfzjzREZ7nbejPJQ5