### PR TITLE
Add Feedback and Suggest to the sidebar nav

### DIFF
--- a/app/_components/site-shell.tsx
+++ b/app/_components/site-shell.tsx
@@ -68,6 +68,8 @@ const BOTTOM_BAR_GROUPS: { href: string; label: string }[][] = [
     { href: "/connect", label: "Connect" },
     { href: "/guidelines", label: "Guidelines" },
     { href: "/submit", label: "Submit" },
+    { href: "/feedback", label: "Feedback" },
+    { href: "/suggest", label: "Suggest" },
     { href: "/status", label: "Status" },
   ],
 ];


### PR DESCRIPTION
Adds `/feedback` and `/suggest` to `BOTTOM_BAR_GROUPS` in the sidebar, in the same third group the footer files them under.

Verified: full `npm run build` green; the prerendered homepage contains `href="/feedback"` and `href="/suggest"` twice each (sidebar + footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196pYaGfzjzREZ7nbejPJQ5